### PR TITLE
Harden branch convergence and App Store artifact audits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,11 +95,9 @@ When two instructions disagree, use this order:
 4. The compact `SESSION_HANDOFF.md` for current, host-qualified state.
 5. Dated research and memories only when they are not expired or superseded.
 
-Normal read, edit, build, test, commit, feature-push, SSH, rsync, and browser
-work must remain usable. Approved tools may consume local credentials internally,
-including when invoked from the Air over SSH, but agents must never dump, print,
-copy, or export raw secret material. Real
-sends, releases, uploads, reboots, and customer/data mutations use their
+Normal read, edit, build, test, commit, feature-push, SSH, rsync, and browser work must remain usable.
+Approved tools may consume local credentials internally, including when invoked from the Air over
+SSH, but agents must never dump, print, copy, or export raw secret material. Real sends, releases, uploads, reboots, and customer/data mutations use their
 canonical approval gates. Irreversible deletion of a home, repository,
 history, production resource, credential, ownership, license, or money is a
 manual user-only action and must be mechanically blocked even in bypass mode.
@@ -160,12 +158,10 @@ the wrapper.
 | Route cost review | `ruby scripts/SaneMaster.rb route_cost_review --json` |
 | Mini screenshot | `scripts/mini/capture-mini-screenshot.sh desktop` or app mode wrapper |
 
-Runtime app tests must attach a live app log stream from before launch/relaunch
-through the tested workflow and save the log receipt path. A GUI/runtime result
-without live logs is invalid because the agent cannot see what is happening.
+Runtime app tests must attach a live app log stream from before launch/relaunch through
+the tested workflow and save the receipt path. GUI/runtime results without live logs are invalid.
 
-If a canonical route fails, fix the route or explain why it is insufficient.
-Do not silently work around it.
+If a canonical route fails, fix it or explain why it is insufficient; do not silently work around it.
 Raw `ssh mini ... screencapture ...` is not a fallback; it is blocked by
 `scripts/hooks/sane_ssh_guard.sh` and the Bash guard dispatcher. Use the
 canonical Mini screenshot wrapper or fix that wrapper.

--- a/config/products.yml
+++ b/config/products.yml
@@ -52,7 +52,7 @@ products:
     domain: sanescan.saneapps.com
     github_repo: sane-apps/SaneScan
     appstore_id: "6770391054"
-    storekit_product_id: com.sanescan.app.pro.annual
+    storekit_product_id: com.sanescan.app.pro.yearly6
 
   sanesync:
     name: SaneSync

--- a/scripts/SaneMaster.rb
+++ b/scripts/SaneMaster.rb
@@ -165,7 +165,7 @@ class SaneMaster
         'release' => { args: '[--full|--deploy|--no-deploy|--skip-notarize|--version X.Y.Z|--notes "..."]', desc: 'Build, sign, notarize, package, and optionally deploy' },
         'upgrade_path_proof' => { args: '', desc: 'Run the configured behavioral upgrade test and write signed Mini proof' },
         'release_preflight' => { args: '', desc: 'Run all pre-release safety checks without building' },
-        'appstore_preflight' => { args: '[--platform macos|ios] [--pkg PATH | --asc-build-id ID --build-number N]', desc: 'Run App Store submission compliance checks and optionally bind the exact submission target' }
+        'appstore_preflight' => { args: '[--platform macos|ios] [--pkg PATH]', desc: 'Run App Store submission checks and bind authorization to an exact fresh package' }
       }
     },
     gen: {
@@ -524,6 +524,7 @@ class SaneMaster
       return
     end
 
+    reject_retired_appstore_reuse!(command, args)
     ensure_work_session_ready!(command)
     maybe_route_to_mini!(command, args)
 
@@ -542,6 +543,20 @@ class SaneMaster
   end
 
   private
+
+  def reject_retired_appstore_reuse!(command, args)
+    return unless %w[appstore_preflight asp].include?(command.to_s)
+
+    retired = %w[--asc-build-id --build-number].select do |flag|
+      Array(args).any? { |arg| arg == flag || arg.start_with?("#{flag}=") }
+    end
+    return if retired.empty?
+
+    warn "❌ Retired App Store preflight option(s): #{retired.join(', ')}"
+    warn 'Existing ASC build reuse is disabled because exact remote bytes cannot be proven.'
+    warn 'Increment the build number, create a fresh package, then run appstore_preflight --platform PLATFORM --pkg PATH.'
+    exit 2
+  end
 
   def auto_dedupe_runtime_apps!(command)
     return if command.nil?
@@ -1866,13 +1881,19 @@ PY
     abort "❌ App Store preflight package not found: #{local_package}" unless File.file?(local_package)
 
     digest = Digest::SHA256.file(local_package).hexdigest
-    binding_dir = File.join(execution_repo, '.sanemaster', 'appstore-preflight-bindings', digest)
+    binding_root = File.join(execution_repo, 'outputs', 'appstore-preflight-bindings')
+    binding_dir = File.join(binding_root, digest)
     remote_package = File.join(binding_dir, File.basename(local_package))
-    ok = ssh_system('mini', "mkdir -p #{Shellwords.escape(binding_dir)}")
+    ok = ssh_system(
+      'mini',
+      "mkdir -p #{Shellwords.escape(binding_dir)} && chmod 700 #{Shellwords.escape(binding_root)} #{Shellwords.escape(binding_dir)}"
+    )
     abort '❌ Failed to prepare Mini App Store preflight package binding directory.' unless ok
 
     ok = route_system('rsync', '-az', '--no-links', local_package, "mini:#{remote_package}")
     abort '❌ Failed to sync exact App Store preflight package to the Mini.' unless ok
+    ok = ssh_system('mini', "chmod 400 #{Shellwords.escape(remote_package)}")
+    abort '❌ Failed to lock exact App Store preflight package on the Mini.' unless ok
 
     routed_args[package_index + 1] = remote_package
     [routed_args, binding_dir]
@@ -3091,15 +3112,13 @@ PY
       examples: ['session_end', 'se', 'session_end --skip-prompts']
     },
     'appstore_preflight' => {
-      usage: 'appstore_preflight (or asp) [--platform macos|ios] [--pkg PATH | --asc-build-id ID --build-number N]',
-      description: 'Run App Store submission compliance checks for active App Store lanes; optionally bind the signed receipt to the exact package or existing ASC build',
+      usage: 'appstore_preflight (or asp) [--platform macos|ios] [--pkg PATH]',
+      description: 'Run App Store submission checks and bind the signed receipt to an exact fresh package; existing ASC build reuse is retired because remote bytes cannot be proven',
       flags: {
         '--platform PLATFORM' => 'Platform for exact submission binding (macos or ios)',
-        '--pkg PATH' => 'Bind authorization to this exact package digest and bundle metadata',
-        '--asc-build-id ID' => 'Bind authorization to an exact existing App Store Connect build ID',
-        '--build-number N' => 'Required CFBundleVersion when binding an existing ASC build'
+        '--pkg PATH' => 'Bind authorization to this exact fresh package digest and bundle metadata'
       },
-      examples: ['appstore_preflight', 'appstore_preflight --platform macos --pkg build/Example.pkg', 'asp --platform ios --asc-build-id BUILD_ID --build-number 100']
+      examples: ['appstore_preflight', 'appstore_preflight --platform macos --pkg build/Example.pkg', 'asp --platform ios --pkg build/Example.ipa']
     },
     'sales' => {
       usage: 'sales [--daily|--month|--products|--fees|--find-customer-orders --email E --name N --product P|--license-status KEY|--disable-license-key KEY|--refund-order ID|--refund-order-number N|--refund-duplicate-license-key KEY --keep-license-key KEY --approval-note PATH|--include-refunded|--json]',

--- a/scripts/appstore_submit.rb
+++ b/scripts/appstore_submit.rb
@@ -250,7 +250,7 @@ def ensure_strict_customer_ui_contract!(project_root)
   sanemaster = File.join(project_root, 'scripts', 'SaneMaster.rb')
   unless File.file?(sanemaster)
     log_error "Missing SaneMaster wrapper at #{sanemaster}; cannot verify strict customer UI contract."
-    return false
+    return :failed
   end
 
   command = sanemaster_invocation(sanemaster)
@@ -963,30 +963,47 @@ end
 
 # ─── Package Metadata ───
 
-def extract_app_info_from_package(pkg_path)
-  read_plist = lambda do |info_path|
-    return nil unless info_path && File.exist?(info_path)
+def app_info_from_plist(info_path)
+  return nil unless info_path && File.file?(info_path)
 
-    bundle_id = `"/usr/libexec/PlistBuddy" -c 'Print :CFBundleIdentifier' #{Shellwords.escape(info_path)} 2>/dev/null`.strip
-    short_version = `"/usr/libexec/PlistBuddy" -c 'Print :CFBundleShortVersionString' #{Shellwords.escape(info_path)} 2>/dev/null`.strip
-    build_number = `"/usr/libexec/PlistBuddy" -c 'Print :CFBundleVersion' #{Shellwords.escape(info_path)} 2>/dev/null`.strip
+  values = %w[CFBundleIdentifier CFBundleShortVersionString CFBundleVersion].map do |key|
+    output, status = Open3.capture2e('/usr/libexec/PlistBuddy', '-c', "Print :#{key}", info_path)
+    return nil unless status.success? && !output.to_s.strip.empty?
 
-    return nil if bundle_id.empty? || short_version.empty? || build_number.empty?
-
-    {
-      bundle_id: bundle_id,
-      short_version: short_version,
-      build_number: build_number
-    }
+    output.to_s.strip
   end
+  { bundle_id: values[0], short_version: values[1], build_number: values[2] }
+rescue StandardError
+  nil
+end
+
+def select_unique_package_app_info(info_paths, expected_bundle_id: nil)
+  candidates = Array(info_paths).uniq.sort.map { |path| app_info_from_plist(path) }.compact
+  unless expected_bundle_id.to_s.empty?
+    candidates = candidates.select { |candidate| candidate[:bundle_id] == expected_bundle_id.to_s }
+  end
+  return nil unless candidates.length == 1
+
+  candidates.first
+end
+
+def top_level_pkg_app_info_paths(expanded_dir)
+  Dir.glob(File.join(expanded_dir, '**', 'Payload', '**', '*.app', 'Contents', 'Info.plist')).select do |path|
+    relative = path.split('/Payload/', 2)[1].to_s
+    app_components = relative.split('/').select { |component| component.end_with?('.app') }
+    app_components.length == 1
+  end.uniq.sort
+end
+
+def extract_app_info_from_package(pkg_path, expected_bundle_id: nil)
 
   if pkg_path.end_with?('.ipa')
     Dir.mktmpdir('asc_info_plist') do |tmpdir|
       unzip_ok = system("unzip -qq -o #{Shellwords.escape(pkg_path)} 'Payload/*.app/Info.plist' -d #{Shellwords.escape(tmpdir)} >/dev/null 2>&1")
       return nil unless unzip_ok
 
-      info_path = Dir.glob(File.join(tmpdir, 'Payload', '*.app', 'Info.plist')).first
-      return read_plist.call(info_path)
+      info_paths = Dir.glob(File.join(tmpdir, 'Payload', '*.app', 'Info.plist'))
+      return select_unique_package_app_info(info_paths, expected_bundle_id: expected_bundle_id)
     end
   elsif pkg_path.end_with?('.pkg')
     Dir.mktmpdir('asc_pkg_info') do |tmpdir|
@@ -994,9 +1011,8 @@ def extract_app_info_from_package(pkg_path)
       expand_ok = system('pkgutil', '--expand-full', pkg_path, expanded, out: File::NULL, err: File::NULL)
       return nil unless expand_ok
 
-      candidates = Dir.glob(File.join(expanded, '**', 'Payload', '*.app', 'Contents', 'Info.plist'))
-      info_path = candidates.find { |p| !p.include?('/Frameworks/') && !p.include?('/PlugIns/') } || candidates.first
-      return read_plist.call(info_path)
+      info_paths = top_level_pkg_app_info_paths(expanded)
+      return select_unique_package_app_info(info_paths, expected_bundle_id: expected_bundle_id)
     end
   end
 
@@ -1005,36 +1021,33 @@ end
 
 # ─── Upload Build ───
 
-def upload_build(pkg_path, app_id:, version:)
-  log_info "Uploading #{File.basename(pkg_path)} via altool..."
-
-  credentials = require_asc_credentials!
+def exact_appstore_upload_command(pkg_path, app_id:, credentials:)
   package_info = extract_app_info_from_package(pkg_path)
-  cmd =
-    if package_info
-      [
-        'xcrun', 'altool', '--upload-package', pkg_path,
-        '-t', pkg_path.end_with?('.ipa') ? 'ios' : 'macos',
-        '--apple-id', app_id,
-        '--bundle-id', package_info[:bundle_id],
-        '--bundle-version', package_info[:build_number],
-        '--bundle-short-version-string', package_info[:short_version],
-        '--wait',
-        '--apiKey', credentials[:key_id],
-        '--apiIssuer', credentials[:issuer_id]
-      ]
-    else
-      [
-        'xcrun', 'altool', '--upload-app',
-        '-f', pkg_path,
-        '--apiKey', credentials[:key_id],
-        '--apiIssuer', credentials[:issuer_id],
-        '-t', pkg_path.end_with?('.ipa') ? 'ios' : 'macos'
-      ]
-    end
+  return nil unless package_info
 
-  output = `#{cmd.map { |c| Shellwords.escape(c) }.join(' ')} 2>&1`
-  success = $?.success?
+  [
+    'xcrun', 'altool', '--upload-package', pkg_path,
+    '-t', pkg_path.end_with?('.ipa') ? 'ios' : 'macos',
+    '--apple-id', app_id,
+    '--bundle-id', package_info[:bundle_id],
+    '--bundle-version', package_info[:build_number],
+    '--bundle-short-version-string', package_info[:short_version],
+    '--wait',
+    '--apiKey', credentials[:key_id],
+    '--apiIssuer', credentials[:issuer_id]
+  ]
+end
+
+def classify_appstore_upload_output(success:, output:)
+  duplicate_upload_patterns = [
+    /already been uploaded/i,
+    /already exists/i,
+    /bundle version must be higher than the previously uploaded version/i,
+    /ENTITY_ERROR\.ATTRIBUTE\.INVALID\.DUPLICATE/i,
+    /attribute with a value that has already been used/i
+  ]
+  return :duplicate if duplicate_upload_patterns.any? { |pattern| output.match?(pattern) }
+
   output_failure_patterns = [
     /upload failed/i,
     /validation failed/i,
@@ -1043,96 +1056,89 @@ def upload_build(pkg_path, app_id:, version:)
     /app sandbox not enabled/i
   ]
   reported_failure = output_failure_patterns.any? { |pattern| output.match?(pattern) }
+  return :uploaded if success && !reported_failure
 
-  if success && !reported_failure
-    log_info 'Upload complete.'
-  else
-    duplicate_upload_patterns = [
-      /already been uploaded/i,
-      /already exists/i,
-      /bundle version must be higher than the previously uploaded version/i,
-      /ENTITY_ERROR\.ATTRIBUTE\.INVALID\.DUPLICATE/i,
-      /attribute with a value that has already been used/i
-    ]
-    if duplicate_upload_patterns.any? { |pattern| output.match?(pattern) }
-      log_info 'Build already uploaded — continuing.'
-      return true
-    end
-    log_error "altool upload failed:\n#{output}"
-    return false
+  :failed
+end
+
+def upload_build(pkg_path, app_id:, version:)
+  log_info "Uploading #{File.basename(pkg_path)} via altool..."
+
+  credentials = require_asc_credentials!
+  cmd = exact_appstore_upload_command(pkg_path, app_id: app_id, credentials: credentials)
+  unless cmd
+    log_error 'Could not reparse one exact top-level app identity from the staged package. Refusing generic upload fallback.'
+    return :failed
   end
 
-  true
+  output = `#{cmd.map { |c| Shellwords.escape(c) }.join(' ')} 2>&1`
+  outcome = classify_appstore_upload_output(success: $?.success?, output: output)
+  case outcome
+  when :uploaded
+    log_info 'Upload complete.'
+  when :duplicate
+    log_error 'Build already exists in ASC. Increment the build number, create a fresh package, and retry the normal upload.'
+  else
+    log_error "altool upload failed:\n#{output}"
+  end
+  outcome
 end
 
 # ─── Poll for Build Processing ───
 
-def asc_build_rows(app_id, asc_platform, token, limit: 50)
-  path = "/builds?filter[app]=#{app_id}&filter[preReleaseVersion.platform]=#{asc_platform}" \
-         "&include=preReleaseVersion&limit=#{limit}"
-  resp = asc_get(path, token: token)
-  return [] unless resp && resp['data']
-
-  pre_versions = {}
-  (resp['included'] || []).each do |entry|
-    next unless entry['type'] == 'preReleaseVersions'
-
-    pre_versions[entry['id']] = entry.dig('attributes', 'version')
-  end
-
-  (resp['data'] || []).map do |build|
-    attrs = build['attributes'] || {}
-    pre_id = build.dig('relationships', 'preReleaseVersion', 'data', 'id')
-    {
-      id: build['id'],
-      build: attrs['version'].to_s,
-      processing: attrs['processingState'].to_s,
-      expired: attrs['expired'],
-      uploaded: attrs['uploadedDate'].to_s,
-      prerelease: pre_versions[pre_id].to_s
-    }
-  end
-end
-
-def summarize_build_rows(rows, max: 6)
-  rows
-    .sort_by { |row| [row[:uploaded].to_s, row[:build].to_s] }
-    .reverse
-    .first(max)
-    .map { |row| "#{row[:build]}@#{row[:prerelease]} (#{row[:processing]})" }
-    .join(', ')
-end
-
-def wait_for_build(app_id, version, asc_platform, token, skip_upload: false)
-  log_info "Waiting for build #{version} to finish processing (up to #{BUILD_POLL_TIMEOUT / 60} min)..."
+def wait_for_build(app_id, build_number, asc_platform, token, expected_marketing_version:)
+  log_info "Waiting for build #{build_number} (version #{expected_marketing_version}) to finish processing (up to #{BUILD_POLL_TIMEOUT / 60} min)..."
 
   deadline = Time.now + BUILD_POLL_TIMEOUT
   build_id = nil
-  skip_upload_presence_checked = false
 
   while Time.now < deadline
-    path = "/builds?filter[app]=#{app_id}&filter[version]=#{version}" \
+    path = "/builds?filter[app]=#{app_id}&filter[version]=#{build_number}" \
            "&filter[preReleaseVersion.platform]=#{asc_platform}" \
            "&filter[processingState]=PROCESSING,VALID,INVALID" \
            "&sort=-uploadedDate&limit=5&include=preReleaseVersion"
     resp = asc_get(path, token: token)
 
     if resp && resp['data']
-      pr_versions = {}
+      prerelease_identities = {}
       (resp['included'] || []).each do |entry|
         next unless entry['type'] == 'preReleaseVersions'
 
-        pr_versions[entry['id']] = entry.dig('attributes', 'platform')
+        prerelease_identities[entry['id']] = {
+          platform: entry.dig('attributes', 'platform').to_s,
+          version: entry.dig('attributes', 'version').to_s
+        }
       end
 
-      # Find build matching our platform
-      build = resp['data'].find do |b|
+      numbered_builds = resp['data'].select do |b|
         attrs = b['attributes'] || {}
-        next false unless attrs['version'].to_s == version.to_s
-
-        pr_id = b.dig('relationships', 'preReleaseVersion', 'data', 'id')
-        platform = pr_versions[pr_id]
-        platform.nil? || platform == asc_platform
+        attrs['version'].to_s == build_number.to_s
+      end
+      if numbered_builds.any?
+        missing_identity = numbered_builds.any? do |build|
+          prerelease_identities[build.dig('relationships', 'preReleaseVersion', 'data', 'id')].nil?
+        end
+        if missing_identity
+          log_error "ASC build #{build_number} is missing included pre-release version identity; refusing ambiguous selection."
+          return nil
+        end
+        exact_builds = numbered_builds.select do |build|
+          identity = prerelease_identities[build.dig('relationships', 'preReleaseVersion', 'data', 'id')]
+          identity[:platform] == asc_platform && identity[:version] == expected_marketing_version.to_s
+        end
+        if exact_builds.empty?
+          identities = numbered_builds.map do |build|
+            prerelease_identities[build.dig('relationships', 'preReleaseVersion', 'data', 'id')]
+          end
+          summary = identities.map { |identity| "#{identity[:version]}@#{identity[:platform]}" }.uniq.join(', ')
+          log_error "ASC build #{build_number} belongs to #{summary}, not #{expected_marketing_version}@#{asc_platform}."
+          return nil
+        end
+        if exact_builds.length != 1
+          log_error "ASC build #{build_number} is ambiguous for #{expected_marketing_version}@#{asc_platform}."
+          return nil
+        end
+        build = exact_builds.first
       end
 
       if build
@@ -1141,26 +1147,16 @@ def wait_for_build(app_id, version, asc_platform, token, skip_upload: false)
 
         case state
         when 'VALID'
-          log_info "Build #{version} processed successfully (ID: #{build_id})"
+          log_info "Build #{build_number} processed successfully (ID: #{build_id})"
           return build_id
         when 'INVALID'
-          log_error "Build #{version} failed processing (INVALID)"
+          log_error "Build #{build_number} failed processing (INVALID)"
           return nil
         else
           log_info "Build processing... (#{state})"
         end
       else
         log_info 'Build not yet visible in ASC...'
-        if skip_upload && !skip_upload_presence_checked
-          rows = asc_build_rows(app_id, asc_platform, token, limit: 25)
-          unless rows.any? { |row| row[:build].to_s == version.to_s }
-            log_error "Requested existing build #{version} is not visible in ASC for #{asc_platform}."
-            summary = summarize_build_rows(rows)
-            log_error(summary.empty? ? 'No candidate builds are currently visible for this platform.' : "Visible builds: #{summary}")
-            return nil
-          end
-          skip_upload_presence_checked = true
-        end
       end
     end
 
@@ -4214,35 +4210,7 @@ def detect_project_build_number(project_root)
 end
 
 def extract_build_number_from_package(pkg_path)
-  if pkg_path.end_with?('.ipa')
-    Dir.mktmpdir('asc_info_plist') do |tmpdir|
-      unzip_ok = system("unzip -qq -o #{Shellwords.escape(pkg_path)} 'Payload/*.app/Info.plist' -d #{Shellwords.escape(tmpdir)} >/dev/null 2>&1")
-      return nil unless unzip_ok
-
-      info_path = Dir.glob(File.join(tmpdir, 'Payload', '*.app', 'Info.plist')).first
-      return nil unless info_path && File.exist?(info_path)
-
-      bundle_version = `"/usr/libexec/PlistBuddy" -c 'Print :CFBundleVersion' #{Shellwords.escape(info_path)} 2>/dev/null`.strip
-      return bundle_version unless bundle_version.empty?
-      nil
-    end
-  elsif pkg_path.end_with?('.pkg')
-    Dir.mktmpdir('asc_pkg_info') do |tmpdir|
-      expanded = File.join(tmpdir, 'expanded')
-      expand_ok = system('pkgutil', '--expand-full', pkg_path, expanded, out: File::NULL, err: File::NULL)
-      return nil unless expand_ok
-
-      candidates = Dir.glob(File.join(expanded, '**', 'Payload', '*.app', 'Contents', 'Info.plist'))
-      info_path = candidates.find { |p| !p.include?('/Frameworks/') && !p.include?('/PlugIns/') } || candidates.first
-      return nil unless info_path && File.exist?(info_path)
-
-      bundle_version = `"/usr/libexec/PlistBuddy" -c 'Print :CFBundleVersion' #{Shellwords.escape(info_path)} 2>/dev/null`.strip
-      return bundle_version unless bundle_version.empty?
-      nil
-    end
-  else
-    nil
-  end
+  extract_app_info_from_package(pkg_path)&.dig(:build_number)
 end
 
 def wait_for_version_state_transition(app_id:, asc_platform:, version_string:, timeout_seconds: 300, interval_seconds: 8)
@@ -4267,7 +4235,7 @@ def appstore_fingerprint_entries(project_root, paths)
   root_real = File.realpath(project_root)
   Array(paths).sort.map do |relative_path|
     next if relative_path == 'outputs/appstore_preflight_status.json'
-    next if relative_path.start_with?('.sanemaster/appstore-preflight-bindings/')
+    next if relative_path.start_with?('outputs/appstore-preflight-bindings/')
 
     absolute_path = File.expand_path(relative_path, root_real)
     raise "fingerprint path escapes project root: #{relative_path}" unless absolute_path.start_with?("#{root_real}/")
@@ -4329,28 +4297,50 @@ rescue StandardError
   nil
 end
 
-def appstore_asc_submission_target(build_id:, build_number:, version:, platform:)
-  {
-    'type' => 'asc_build',
-    'platform' => platform.to_s.downcase,
-    'ascBuildId' => build_id.to_s,
-    'version' => version.to_s,
-    'build' => build_number.to_s
-  }
-end
-
 def appstore_submission_targets_match?(receipt_target, expected_target)
   return false unless receipt_target.is_a?(Hash) && expected_target.is_a?(Hash)
+  return false unless expected_target['type'].to_s == 'package'
 
-  keys = case expected_target['type'].to_s
-         when 'package'
-           %w[type platform fileName sha256 size bundleId version build]
-         when 'asc_build'
-           %w[type platform ascBuildId version build]
-         else
-           return false
-         end
+  keys = %w[type platform fileName sha256 size bundleId version build]
   keys.all? { |key| receipt_target[key].to_s == expected_target[key].to_s }
+end
+
+def appstore_package_bytes_match_target?(pkg_path, submission_target)
+  return false unless submission_target.is_a?(Hash) && submission_target['type'].to_s == 'package'
+  return false unless File.file?(pkg_path)
+
+  Digest::SHA256.file(pkg_path).hexdigest == submission_target['sha256'].to_s &&
+    File.size(pkg_path).to_s == submission_target['size'].to_s
+rescue StandardError
+  false
+end
+
+def stage_appstore_package(pkg_path, project_root:)
+  return false unless File.file?(pkg_path)
+
+  project = File.realpath(project_root)
+  bindings_root = File.join(project, 'outputs', 'appstore-preflight-bindings')
+  FileUtils.mkdir_p(bindings_root, mode: 0o700)
+  metadata = File.lstat(bindings_root)
+  return false unless metadata.directory? && !metadata.symlink?
+  return false unless File.realpath(bindings_root).start_with?("#{project}/")
+
+  File.chmod(0o700, bindings_root)
+  dir = Dir.mktmpdir('upload-', bindings_root)
+  File.chmod(0o700, dir)
+  staged_path = File.join(dir, File.basename(pkg_path))
+  FileUtils.copy_file(pkg_path, staged_path)
+  File.chmod(0o400, staged_path)
+  at_exit do
+    FileUtils.remove_entry_secure(dir) if Dir.exist?(dir)
+    Dir.rmdir(bindings_root) if Dir.exist?(bindings_root) && Dir.empty?(bindings_root)
+  rescue SystemCallError
+    nil
+  end
+  staged_path
+rescue StandardError => e
+  log_error "Could not create immutable verified upload staging copy: #{e.message}"
+  false
 end
 
 def refresh_appstore_preflight_binding(project_root:, submission_target:, command_runner: nil)
@@ -4358,14 +4348,7 @@ def refresh_appstore_preflight_binding(project_root:, submission_target:, comman
   return [false, "missing canonical preflight command: #{script}"] unless File.file?(script)
 
   command = [RbConfig.ruby, script, 'appstore_preflight', '--platform', submission_target.fetch('platform')]
-  if submission_target['type'] == 'package'
-    command += ['--pkg', submission_target.fetch('path')]
-  else
-    command += [
-      '--asc-build-id', submission_target.fetch('ascBuildId'),
-      '--build-number', submission_target.fetch('build')
-    ]
-  end
+  command += ['--pkg', submission_target.fetch('path')]
 
   success = command_runner ? command_runner.call(command) : system(*command)
   [success == true, success == true ? command : 'App Store preflight submission binding failed']
@@ -4398,7 +4381,7 @@ def fresh_appstore_preflight_receipt?(project_root:, app_id:, version:, platform
   end
 
   unless appstore_submission_targets_match?(receipt['submissionTarget'], submission_target)
-    return [false, 'appstore_preflight receipt is not bound to the exact package or ASC build selected for submission']
+    return [false, 'appstore_preflight receipt is not bound to the exact fresh package selected for submission']
   end
 
   generated_at = Time.parse(receipt['generatedAt'].to_s)
@@ -4433,7 +4416,7 @@ OptionParser.new do |opts|
   opts.on('--build-number NUMBER', 'Build number override (CFBundleVersion)') { |v| options[:build_number] = v }
   opts.on('--platform PLATFORM', 'macos or ios') { |v| options[:platform] = v }
   opts.on('--project-root PATH', 'Project root directory') { |v| options[:project_root] = v }
-  opts.on('--skip-upload', 'Skip binary upload; use existing processed build in ASC') { options[:skip_upload] = true }
+  opts.on('--skip-upload', 'Retired: existing ASC build reuse is not safely supported') { options[:skip_upload] = true }
   opts.on('--skip-screenshots', 'Skip screenshot upload; use screenshots already present in ASC') { options[:skip_screenshots] = true }
   opts.on('--screenshots-only', 'Upload screenshots to an existing ASC version (no upload, no build attach, no submission)') { options[:screenshots_only] = true }
   opts.on('--iap-only', 'Ensure configured App Store IAP metadata is complete and exit') { options[:iap_only] = true }
@@ -4451,6 +4434,12 @@ OptionParser.new do |opts|
   opts.on('--sync-metadata-only', 'Sync metadata/accessibility/review fields for an existing version (no upload, no submission)') { options[:sync_metadata_only] = true }
   opts.on('--test-screenshots', 'Test screenshot resize only (no API calls)') { options[:test_screenshots] = true }
 end.parse!
+
+if options[:skip_upload]
+  log_error '--skip-upload is retired because the exact remote ASC bytes cannot be proven.'
+  log_error 'Increment the build number, create a fresh package, and use the normal upload path.'
+  exit 1
+end
 
 # Test screenshots mode
 if options[:test_screenshots]
@@ -4983,8 +4972,7 @@ if options[:iap_only]
 end
 
 # Validate required options
-required = %i[app_id version platform project_root]
-required << :pkg unless options[:skip_upload]
+required = %i[pkg app_id version platform project_root]
 required.each do |key|
   unless options[key]
     log_error "Missing required option: --#{key.to_s.tr('_', '-')}"
@@ -5004,7 +4992,7 @@ unless asc_platform
   exit 1
 end
 
-if !options[:skip_upload] && !File.exist?(pkg_path)
+unless File.exist?(pkg_path)
   log_error "Package not found: #{pkg_path}"
   exit 1
 end
@@ -5033,61 +5021,40 @@ if !config_app_id.empty?
   end
 end
 
-artifact_label = options[:skip_upload] ? 'existing ASC build' : File.basename(pkg_path)
-log_info "App Store submission: #{artifact_label} v#{version} (#{platform})"
+log_info "App Store submission: #{File.basename(pkg_path)} v#{version} (#{platform})"
 log_info "App ID: #{app_id}"
 
-build_number =
-  if options[:build_number]
-    options[:build_number].to_s
-  elsif options[:skip_upload]
-    detected_build_number = detect_project_build_number(project_root)
-    if detected_build_number
-      log_info "Using build number #{detected_build_number} from project metadata."
-      detected_build_number
-    else
-      default_build_number(version)
-    end
-  end
+build_number = options[:build_number]&.to_s
+
+staged_pkg_path = stage_appstore_package(pkg_path, project_root: project_root)
+unless staged_pkg_path
+  log_error 'Could not stage a private immutable copy of the App Store package.'
+  exit 1
+end
+pkg_path = staged_pkg_path
+package_target = appstore_package_submission_target(pkg_path, platform: platform)
+unless package_target
+  log_error 'Could not extract one exact top-level app identity from the App Store package. Refusing submission.'
+  exit 1
+end
+expected_package_platform = pkg_path.end_with?('.ipa') ? 'ios' : (pkg_path.end_with?('.pkg') ? 'macos' : '')
+if expected_package_platform != platform.to_s.downcase
+  log_error "Package type does not match submission platform: package=#{expected_package_platform.inspect}, submit=#{platform}"
+  exit 1
+end
+if package_target['version'] != version.to_s
+  log_error "Package version #{package_target['version']} does not match requested version #{version}."
+  exit 1
+end
+if build_number && package_target['build'] != build_number
+  log_error "Package build #{package_target['build']} does not match --build-number #{build_number}."
+  exit 1
+end
+build_number = package_target['build']
 
 token = nil
 build_id = nil
-submission_target = nil
-if options[:skip_upload]
-  token = generate_jwt
-  build_id = wait_for_build(app_id, build_number, asc_platform, token, skip_upload: true)
-  unless build_id
-    log_error "Requested reused build #{build_number} was not found. Refusing version-string fallback in --skip-upload mode."
-    exit 1
-  end
-  submission_target = appstore_asc_submission_target(
-    build_id: build_id,
-    build_number: build_number,
-    version: version,
-    platform: platform
-  )
-else
-  submission_target = appstore_package_submission_target(pkg_path, platform: platform)
-  unless submission_target
-    log_error 'Could not extract an exact identity from the App Store package. Refusing upload.'
-    exit 1
-  end
-
-  expected_package_platform = pkg_path.end_with?('.ipa') ? 'ios' : (pkg_path.end_with?('.pkg') ? 'macos' : '')
-  if expected_package_platform != platform.to_s.downcase
-    log_error "Package type does not match submission platform: package=#{expected_package_platform.inspect}, submit=#{platform}"
-    exit 1
-  end
-  if submission_target['version'] != version.to_s
-    log_error "Package version #{submission_target['version']} does not match requested version #{version}."
-    exit 1
-  end
-  if options[:build_number] && submission_target['build'] != options[:build_number].to_s
-    log_error "Package build #{submission_target['build']} does not match --build-number #{options[:build_number]}."
-    exit 1
-  end
-  build_number = submission_target['build']
-end
+submission_target = package_target
 
 preflight_ok, preflight_detail = fresh_appstore_preflight_receipt?(
   project_root: project_root,
@@ -5122,28 +5089,28 @@ end
 log_info "Fresh App Store preflight receipt: #{preflight_detail}"
 
 # Step 1: Upload build
-unless options[:skip_upload]
-  unless upload_build(pkg_path, app_id: app_id, version: version)
-    log_error 'Build upload failed. Aborting.'
-    exit 1
-  end
-else
-  log_info 'Skipping binary upload (--skip-upload).'
+unless appstore_package_bytes_match_target?(pkg_path, package_target)
+  log_error 'App Store package bytes changed after exact-target preflight. Refusing to upload an unaudited package.'
+  exit 1
+end
+upload_outcome = upload_build(pkg_path, app_id: app_id, version: version)
+if upload_outcome == :duplicate
+  log_error 'Existing-build reuse is disabled because exact remote bytes cannot be proven.'
+  log_error 'Increment the build number, create a fresh package, and retry the normal upload.'
+  exit 1
+elsif upload_outcome == :failed
+  log_error 'Build upload failed. Aborting.'
+  exit 1
 end
 
 # Step 2: Wait for processing
-unless options[:skip_upload]
-  token = generate_jwt
-  build_id = wait_for_build(app_id, build_number, asc_platform, token, skip_upload: false)
-  unless build_id
-    # Some older projects used the marketing version as CFBundleVersion.
-    log_info "Retrying build lookup with version string #{version}..."
-    build_id = wait_for_build(app_id, version, asc_platform, token, skip_upload: false)
-  end
-end
-
+token = generate_jwt
+build_id = wait_for_build(
+  app_id, build_number, asc_platform, token,
+  expected_marketing_version: version
+)
 unless build_id
-  log_error 'Build not found after processing. Check App Store Connect manually.'
+  log_error "Uploaded build #{build_number} was not found by exact build number, marketing version, and platform."
   exit 1
 end
 

--- a/scripts/appstore_submit_guardrail_test.rb
+++ b/scripts/appstore_submit_guardrail_test.rb
@@ -9,11 +9,14 @@ require_relative 'appstore_submit'
 
 APPSTORE_PREFLIGHT_TEST_SIGNER = ReleaseReceiptSigner.test_signer(secret: 'appstore-preflight-guardrail-test')
 APPSTORE_PREFLIGHT_ASC_TARGET = {
-  'type' => 'asc_build',
+  'type' => 'package',
   'platform' => 'ios',
-  'ascBuildId' => 'asc-build-123',
   'version' => '1.0',
-  'build' => '100'
+  'build' => '100',
+  'fileName' => 'Example.ipa',
+  'sha256' => 'a' * 64,
+  'size' => 42,
+  'bundleId' => 'com.example.app'
 }.freeze
 
 def with_env(overrides)
@@ -27,6 +30,21 @@ ensure
   previous.each do |key, value|
     value == :__missing__ ? ENV.delete(key) : ENV[key] = value
   end
+end
+
+def write_submit_test_plist(path, bundle_id:)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.write(
+    path,
+    <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <plist version="1.0"><dict>
+        <key>CFBundleIdentifier</key><string>#{bundle_id}</string>
+        <key>CFBundleShortVersionString</key><string>1.0</string>
+        <key>CFBundleVersion</key><string>100</string>
+      </dict></plist>
+    PLIST
+  )
 end
 
 class AppStoreSubmitGuardrailHarness
@@ -196,6 +214,16 @@ class AppStoreSubmitGuardrailHarness
   end
 end
 
+class AppStoreBuildWaitHarness
+  def initialize(response)
+    @response = response
+  end
+
+  def asc_get(*_args, **_kwargs)
+    @response
+  end
+end
+
 def build_metadata_config(
   marketing_url: nil,
   review_notes: 'Basic is free. This App Store build unlocks Pro with an in-app purchase. No external checkout or license key is used.'
@@ -340,7 +368,7 @@ exit(run_tests('App Store Submit Guardrail Tests') do
       true
     end
 
-    test('rejects a receipt bound to a different exact ASC build identity') do
+    test('rejects a receipt bound to different exact package bytes') do
       Dir.mktmpdir('mismatched-appstore-build-') do |dir|
         FileUtils.mkdir_p(File.join(dir, 'outputs'))
         File.write(File.join(dir, '.saneprocess'), "name: Example\n")
@@ -360,7 +388,7 @@ exit(run_tests('App Store Submit Guardrail Tests') do
           producer: 'saneprocess.appstore_preflight.v1'
         )
 
-        different_target = APPSTORE_PREFLIGHT_ASC_TARGET.merge('ascBuildId' => 'asc-build-999')
+        different_target = APPSTORE_PREFLIGHT_ASC_TARGET.merge('sha256' => 'b' * 64)
         ok, detail = fresh_appstore_preflight_receipt?(
           project_root: dir,
           app_id: '123',
@@ -370,9 +398,23 @@ exit(run_tests('App Store Submit Guardrail Tests') do
           receipt_signer: APPSTORE_PREFLIGHT_TEST_SIGNER
         )
 
-        assert(!ok, 'expected a different ASC build ID to invalidate preflight authorization')
-        assert_includes(detail, 'exact package or ASC build')
+        assert(!ok, 'expected different package bytes to invalidate preflight authorization')
+        assert_includes(detail, 'exact fresh package')
       end
+      true
+    end
+
+    test('--skip-upload is retired with actionable fresh-build guidance') do
+      output, status = Open3.capture2e(
+        RbConfig.ruby,
+        File.expand_path('appstore_submit.rb', __dir__),
+        '--skip-upload', '--app-id', '123', '--version', '1.0',
+        '--platform', 'ios', '--project-root', Dir.tmpdir
+      )
+      assert(!status.success?)
+      assert_includes(output, '--skip-upload is retired')
+      assert_includes(output, 'exact remote ASC bytes cannot be proven')
+      assert_includes(output, 'Increment the build number')
       true
     end
 
@@ -393,6 +435,70 @@ exit(run_tests('App Store Submit Guardrail Tests') do
         !appstore_submission_targets_match?(target, target.merge('sha256' => 'b' * 64)),
         'different package bytes must not share authorization'
       )
+      true
+    end
+
+    test('refuses package bytes changed after exact-target preflight') do
+      Dir.mktmpdir('appstore-package-byte-binding-') do |dir|
+        path = File.join(dir, 'Example.ipa')
+        File.write(path, 'audited bytes')
+        target = {
+          'type' => 'package',
+          'sha256' => Digest::SHA256.file(path).hexdigest,
+          'size' => File.size(path)
+        }
+
+        assert(appstore_package_bytes_match_target?(path, target))
+        File.write(path, 'different unaudited bytes')
+        assert(!appstore_package_bytes_match_target?(path, target))
+      end
+      true
+    end
+
+    test('uploads from a private read-only verified staging copy immune to source mutation') do
+      Dir.mktmpdir('appstore-package-staging-') do |dir|
+        source = File.join(dir, 'Example.ipa')
+        File.write(source, 'audited bytes')
+        target = {
+          'type' => 'package',
+          'sha256' => Digest::SHA256.file(source).hexdigest,
+          'size' => File.size(source)
+        }
+        fingerprint_before_staging = appstore_worktree_fingerprint(dir)
+        staged = stage_appstore_package(source, project_root: dir)
+        assert(staged, 'expected verified staging to succeed')
+        assert(staged.start_with?(File.join(File.realpath(dir), 'outputs', 'appstore-preflight-bindings')))
+        assert_eq(File.stat(File.dirname(staged)).mode & 0o777, 0o700)
+        assert_eq(File.stat(staged).mode & 0o777, 0o400)
+        assert_eq(appstore_worktree_fingerprint(dir), fingerprint_before_staging)
+
+        File.write(source, 'mutated source bytes')
+        assert(appstore_package_bytes_match_target?(staged, target))
+        assert(!appstore_package_bytes_match_target?(source, target))
+        assert_eq(File.read(staged), 'audited bytes')
+      end
+      true
+    end
+
+    test('classifies new duplicate and failed uploads distinctly') do
+      assert_eq(classify_appstore_upload_output(success: true, output: 'No errors uploading'), :uploaded)
+      assert_eq(classify_appstore_upload_output(success: false, output: 'Bundle already exists'), :duplicate)
+      assert_eq(classify_appstore_upload_output(success: true, output: 'Upload succeeded but bundle already exists'), :duplicate)
+      assert_eq(classify_appstore_upload_output(success: false, output: 'Validation failed'), :failed)
+      true
+    end
+
+    test('has no generic upload fallback when exact package identity cannot be reparsed') do
+      Dir.mktmpdir('appstore-exact-upload-command-') do |dir|
+        invalid = File.join(dir, 'Invalid.ipa')
+        File.write(invalid, 'not an ipa')
+        command = exact_appstore_upload_command(
+          invalid,
+          app_id: '123',
+          credentials: { key_id: 'KEY', issuer_id: 'ISSUER' }
+        )
+        assert_eq(command, nil)
+      end
       true
     end
 
@@ -547,6 +653,120 @@ exit(run_tests('App Store Submit Guardrail Tests') do
 
         assert(!ensure_strict_customer_ui_contract!(dir), 'expected failed strict UI contract to block upload')
       end
+      true
+    end
+  end
+
+  test_category('Package identity selection') do
+    test('selects a unique expected app identity instead of the first plist') do
+      Dir.mktmpdir('submit-package-selection-') do |dir|
+        helper = File.join(dir, 'AHelper.app', 'Info.plist')
+        submitted = File.join(dir, 'ZSubmitted.app', 'Info.plist')
+        write_submit_test_plist(helper, bundle_id: 'com.example.helper')
+        write_submit_test_plist(submitted, bundle_id: 'com.example.submitted')
+
+        info = select_unique_package_app_info(
+          [helper, submitted],
+          expected_bundle_id: 'com.example.submitted'
+        )
+
+        assert_eq(info[:bundle_id], 'com.example.submitted')
+      end
+      true
+    end
+
+    test('fails closed when package identity is ambiguous or unreadable') do
+      Dir.mktmpdir('submit-package-ambiguous-') do |dir|
+        first = File.join(dir, 'First.app', 'Info.plist')
+        second = File.join(dir, 'Second.app', 'Info.plist')
+        write_submit_test_plist(first, bundle_id: 'com.example.same')
+        write_submit_test_plist(second, bundle_id: 'com.example.same')
+
+        assert_eq(select_unique_package_app_info([first, second]), nil)
+        File.write(first, 'not a plist')
+        assert_eq(select_unique_package_app_info([first]), nil)
+      end
+      true
+    end
+
+    test('finds pkg app identities below install roots and excludes nested helper apps') do
+      Dir.mktmpdir('submit-pkg-layout-') do |dir|
+        submitted = File.join(dir, 'component', 'Payload', 'Applications', 'Submitted.app', 'Contents', 'Info.plist')
+        nested = File.join(
+          dir, 'component', 'Payload', 'Applications', 'Submitted.app', 'Contents',
+          'Helpers', 'Nested.app', 'Contents', 'Info.plist'
+        )
+        write_submit_test_plist(submitted, bundle_id: 'com.example.submitted')
+        write_submit_test_plist(nested, bundle_id: 'com.example.nested')
+
+        assert_eq(top_level_pkg_app_info_paths(dir), [submitted])
+      end
+      true
+    end
+  end
+
+  test_category('Exact ASC build identity') do
+    test('requires build number marketing version and platform to match one included identity') do
+      response = {
+        'data' => [{
+          'id' => 'build-1',
+          'type' => 'builds',
+          'attributes' => { 'version' => '100', 'processingState' => 'VALID' },
+          'relationships' => { 'preReleaseVersion' => { 'data' => { 'id' => 'pre-1' } } }
+        }],
+        'included' => [{
+          'id' => 'pre-1',
+          'type' => 'preReleaseVersions',
+          'attributes' => { 'version' => '1.0', 'platform' => 'IOS' }
+        }]
+      }
+      harness = AppStoreBuildWaitHarness.new(response)
+      build_id = harness.send(
+        :wait_for_build,
+        'app-1', '100', 'IOS', 'token',
+        expected_marketing_version: '1.0'
+      )
+      assert_eq(build_id, 'build-1')
+      true
+    end
+
+    test('rejects duplicate build numbers belonging to another marketing version') do
+      response = {
+        'data' => [{
+          'id' => 'wrong-version',
+          'attributes' => { 'version' => '100', 'processingState' => 'VALID' },
+          'relationships' => { 'preReleaseVersion' => { 'data' => { 'id' => 'pre-old' } } }
+        }],
+        'included' => [{
+          'id' => 'pre-old',
+          'type' => 'preReleaseVersions',
+          'attributes' => { 'version' => '0.9', 'platform' => 'IOS' }
+        }]
+      }
+      build_id = AppStoreBuildWaitHarness.new(response).send(
+        :wait_for_build,
+        'app-1', '100', 'IOS', 'token',
+        expected_marketing_version: '1.0'
+      )
+      assert_eq(build_id, nil)
+      true
+    end
+
+    test('fails closed when ASC omits included pre-release identity') do
+      response = {
+        'data' => [{
+          'id' => 'unbound-build',
+          'attributes' => { 'version' => '100', 'processingState' => 'VALID' },
+          'relationships' => { 'preReleaseVersion' => { 'data' => { 'id' => 'missing' } } }
+        }],
+        'included' => []
+      }
+      build_id = AppStoreBuildWaitHarness.new(response).send(
+        :wait_for_build,
+        'app-1', '100', 'IOS', 'token',
+        expected_marketing_version: '1.0'
+      )
+      assert_eq(build_id, nil)
       true
     end
   end

--- a/scripts/hooks/release_receipt_signer.rb
+++ b/scripts/hooks/release_receipt_signer.rb
@@ -55,7 +55,7 @@ module ReleaseReceiptSigner
       payload_type: 'appstore_preflight_status',
       command: 'appstore_preflight',
       receipt: 'outputs/appstore_preflight_status.json',
-      option_flags: %w[--platform --pkg --asc-build-id --build-number],
+      option_flags: %w[--platform --pkg],
       receipt_optional_on_success: true
     },
     'saneprocess.upgrade_path_proof.v1' => {

--- a/scripts/hooks/sane_bash_guards.rb
+++ b/scripts/hooks/sane_bash_guards.rb
@@ -364,6 +364,9 @@ end
 def safari_automation_command?(command)
   return false unless command
 
+  legacy_wrapper = /(?:\A|[;&|(){}\n]|&&|\|\|)\s*(?:\S*\/)?mini-safari\.sh(?:\s|$)/
+  return true if command.match?(legacy_wrapper)
+
   tells_safari = /tell\s+app(?:lication)?\s+.?["']Safari["']/i
   return true if command.match?(/\bosascript\b/) && command.match?(tells_safari)
 

--- a/scripts/sanemaster/command_registry_test.rb
+++ b/scripts/sanemaster/command_registry_test.rb
@@ -29,6 +29,36 @@ exit(run_tests('SaneMaster Command Alias Tests') do
       true
     end
 
+    test('App Store help requires a fresh local package and retires remote build reuse') do
+      summary = SaneMaster::COMMANDS.fetch(:build).fetch(:commands).fetch('appstore_preflight')
+      detail = SaneMaster::COMMAND_DETAILS.fetch('appstore_preflight')
+      assert_includes(summary[:args], '--pkg PATH')
+      assert_includes(detail[:description], 'reuse is retired')
+      assert(!detail[:examples].any? { |example| example.include?('--asc-build-id') })
+      true
+    end
+
+    test('actual App Store preflight CLI rejects retired ASC reuse before receipt signing') do
+      output, status = Open3.capture2e(
+        {
+          'SANEMASTER_DISABLE_MINI_ROUTING' => '1',
+          'SANEMASTER_SUPPRESS_WORKFLOW_RECEIPT' => '1'
+        },
+        RbConfig.ruby,
+        File.expand_path('../SaneMaster.rb', __dir__),
+        'appstore_preflight',
+        '--asc-build-id=build-123',
+        '--build-number', '100'
+      )
+
+      assert(!status.success?, 'retired ASC reuse must fail before the canonical signer runs')
+      assert_includes(output, 'Retired App Store preflight option(s): --asc-build-id, --build-number')
+      assert_includes(output, 'exact remote bytes cannot be proven')
+      assert_includes(output, 'create a fresh package')
+      assert(!output.include?('unsupported canonical producer option'), 'operator must receive the actionable tombstone')
+      true
+    end
+
     test('removed registry review command is not advertised') do
       assert(!SaneMaster::COMMANDS.fetch(:check).fetch(:commands).key?('registry_review'))
       assert(!SaneMaster::COMMAND_DETAILS.key?('registry_review'))

--- a/scripts/sanemaster/release.rb
+++ b/scripts/sanemaster/release.rb
@@ -1947,6 +1947,358 @@ module SaneMasterModules
       markers
     end
 
+    APPSTORE_PERMISSION_PLIST_KEYS = %w[
+      NSAccessibilityUsageDescription
+      NSAppleEventsUsageDescription
+    ].freeze
+
+    def appstore_plistbuddy_capture(*args)
+      Open3.capture2e('/usr/libexec/PlistBuddy', *args)
+    end
+
+    def appstore_built_plist_permission_report(info_plist)
+      issues = []
+      declarations = APPSTORE_PERMISSION_PLIST_KEYS.to_h { |key| [key, false] }
+      unless File.file?(info_plist)
+        issues << 'App Store artifact audit could not find the built Info.plist'
+        return { verified: false, root_dump: '', declarations: declarations, issues: issues }
+      end
+
+      root_dump, root_status = appstore_plistbuddy_capture('-c', 'Print', info_plist)
+      unless root_status.success?
+        detail = summarized_output_tail(root_dump)
+        message = 'App Store artifact audit could not parse the built Info.plist with PlistBuddy'
+        message += ": #{detail}" unless detail.empty?
+        issues << message
+        return { verified: false, root_dump: '', declarations: declarations, issues: issues }
+      end
+
+      APPSTORE_PERMISSION_PLIST_KEYS.each do |key|
+        output, status = appstore_plistbuddy_capture('-c', "Print :#{key}", info_plist)
+        if status.success?
+          declarations[key] = true
+        elsif !output.to_s.match?(/Does Not Exist/i)
+          detail = summarized_output_tail(output)
+          message = "App Store artifact audit could not query built Info.plist root key #{key}"
+          message += ": #{detail}" unless detail.empty?
+          issues << message
+        end
+      end
+
+      {
+        verified: issues.empty?,
+        root_dump: root_dump.to_s,
+        declarations: declarations,
+        issues: issues
+      }
+    rescue StandardError => e
+      {
+        verified: false,
+        root_dump: '',
+        declarations: declarations,
+        issues: ["App Store artifact audit could not inspect the built Info.plist: #{e.message}"]
+      }
+    end
+
+    def appstore_permission_artifact_findings(review_notes_blob:, declarations:, artifact_blob:, strings_out:, nm_out:, otool_out:,
+                                               payload_label: nil)
+      issues = []
+      warnings = []
+      suffix = payload_label.to_s.empty? ? '' : " in #{payload_label}"
+
+      if review_notes_blob.match?(/does not request accessibility/i) &&
+         declarations['NSAccessibilityUsageDescription']
+        issues << "Review notes claim no Accessibility request, but built Info.plist still declares NSAccessibilityUsageDescription#{suffix}"
+      end
+
+      if review_notes_blob.match?(/does not request.*apple events|no apple events/i) &&
+         declarations['NSAppleEventsUsageDescription']
+        issues << "Review notes claim no Apple Events request, but built Info.plist still declares NSAppleEventsUsageDescription#{suffix}"
+      end
+
+      accessibility_markers = []
+      accessibility_markers << 'ApplicationServices linkage' if otool_out.include?('ApplicationServices.framework')
+      accessibility_markers << 'AXIsProcessTrusted symbol' if nm_out.match?(/_AXIsProcessTrusted/)
+      accessibility_markers << 'Accessibility settings deep link' if strings_out.include?('Privacy_Accessibility')
+      if accessibility_markers.any?
+        issues << "Built App Store artifact still contains Accessibility markers (#{accessibility_markers.join(', ')})#{suffix}"
+      end
+
+      apple_events_markers = []
+      apple_events_markers << 'osascript runtime' if artifact_blob.include?('/usr/bin/osascript')
+      if declarations['NSAppleEventsUsageDescription']
+        apple_events_markers << 'Apple Events usage description'
+      end
+      if apple_events_markers.any?
+        warnings << "Built App Store artifact still contains Apple Events markers (#{apple_events_markers.join(', ')})#{suffix} — verify App Review notes and App Store policy fit"
+      end
+
+      { issues: issues, warnings: warnings }
+    end
+
+    def appstore_artifact_capture(*command)
+      Open3.capture2e(*command)
+    end
+
+    def appstore_macho_file?(path)
+      magic = File.binread(path, 4)
+      ["\xFE\xED\xFA\xCE", "\xCE\xFA\xED\xFE", "\xFE\xED\xFA\xCF", "\xCF\xFA\xED\xFE",
+       "\xCA\xFE\xBA\xBE", "\xBE\xBA\xFE\xCA"].any? { |candidate| magic == candidate.b }
+    rescue StandardError
+      false
+    end
+
+    def appstore_runnable_non_macho_file?(path)
+      metadata = File.stat(path)
+      return false unless metadata.file?
+      return false if appstore_macho_file?(path)
+      return true unless (metadata.mode & 0o111).zero?
+
+      File.open(path, 'rb') { |file| file.read(2) } == '#!'
+    rescue StandardError
+      false
+    end
+
+    def appstore_shipped_executable_inventory(app_dir:, platform:, main_binary:)
+      issues = []
+      paths = [main_binary]
+      string_only_paths = []
+      roots = if platform.to_s.downcase == 'macos'
+                %w[Contents/Helpers Contents/PlugIns Contents/XPCServices Contents/Library/LoginItems Contents/Frameworks]
+              else
+                %w[PlugIns Watch AppClips Frameworks]
+              end.map { |relative| File.join(app_dir, relative) }.select { |path| Dir.exist?(path) }
+
+      bundle_dirs = roots.flat_map do |root|
+        %w[app appex xpc].flat_map { |extension| Dir.glob(File.join(root, '**', "*.#{extension}")) }
+      end.select { |path| File.directory?(path) }.uniq.sort
+      bundle_dirs.each do |bundle_dir|
+        mac_layout = Dir.exist?(File.join(bundle_dir, 'Contents'))
+        info_path = File.join(bundle_dir, mac_layout ? 'Contents/Info.plist' : 'Info.plist')
+        unless File.file?(info_path)
+          issues << "Recognized embedded bundle is missing Info.plist: #{bundle_dir.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')}"
+          next
+        end
+        executable_out, executable_status = appstore_plistbuddy_capture('-c', 'Print :CFBundleExecutable', info_path)
+        executable = executable_out.to_s.strip
+        unless executable_status.success? && !executable.empty?
+          issues << "Recognized embedded bundle has no readable CFBundleExecutable: #{bundle_dir.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')}"
+          next
+        end
+        executable_path = File.join(bundle_dir, mac_layout ? 'Contents/MacOS' : '', executable)
+        if File.file?(executable_path)
+          paths << executable_path
+        else
+          issues << "Recognized embedded bundle executable is missing: #{executable_path.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')}"
+        end
+      end
+
+      framework_dirs = roots.flat_map { |root| Dir.glob(File.join(root, '**', '*.framework')) }
+        .select { |path| File.directory?(path) }.uniq.sort
+      framework_dirs.each do |framework_dir|
+        info_paths = [
+          File.join(framework_dir, 'Info.plist'),
+          File.join(framework_dir, 'Resources', 'Info.plist'),
+          *Dir.glob(File.join(framework_dir, 'Versions', '*', 'Resources', 'Info.plist'))
+        ].select { |path| File.file?(path) }.uniq
+        if info_paths.empty?
+          relative = framework_dir.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')
+          issues << "Recognized framework is missing Info.plist: #{relative}"
+          next
+        end
+        executable_names = info_paths.map do |info_path|
+          output, status = appstore_plistbuddy_capture('-c', 'Print :CFBundleExecutable', info_path)
+          unless status.success? && !output.to_s.strip.empty?
+            issues << "Recognized framework has an unreadable CFBundleExecutable: #{info_path.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')}"
+            next
+          end
+          output.to_s.strip
+        end.compact.uniq
+        candidates = executable_names.flat_map do |name|
+          [
+            File.join(framework_dir, name),
+            File.join(framework_dir, 'Versions', 'Current', name),
+            *Dir.glob(File.join(framework_dir, 'Versions', '*', name))
+          ]
+        end.select { |path| File.file?(path) }
+        candidates = candidates.group_by { |path| File.realpath(path) rescue File.expand_path(path) }.values.map(&:first)
+        if candidates.length == 1
+          paths << candidates.first
+        else
+          relative = framework_dir.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')
+          issues << "Recognized framework executable identity is #{candidates.empty? ? 'missing' : 'ambiguous'}: #{relative}"
+        end
+      end
+
+      framework_roots = roots.select { |root| File.basename(root) == 'Frameworks' }
+      bundle_dirs.each do |bundle_dir|
+        framework_roots << File.join(bundle_dir, 'Frameworks')
+        framework_roots << File.join(bundle_dir, 'Contents', 'Frameworks')
+      end
+      framework_roots.select! { |root| Dir.exist?(root) }
+      framework_roots.uniq!
+      framework_roots.each do |root|
+        Dir.glob(File.join(root, '**', '*.dylib')).select { |path| File.file?(path) }.each { |path| paths << path }
+      end
+      roots.each do |root|
+        Dir.glob(File.join(root, '**', '*')).select { |path| File.file?(path) }.each do |path|
+          relative_to_root = path.sub(%r{\A#{Regexp.escape(root)}/?}, '')
+          next if relative_to_root.split(File::SEPARATOR).include?('Resources')
+
+          if appstore_macho_file?(path)
+            paths << path
+          elsif appstore_runnable_non_macho_file?(path)
+            paths << path
+            string_only_paths << path
+          end
+        end
+      end
+      paths = paths.group_by { |path| File.realpath(path) rescue File.expand_path(path) }.values.map(&:first)
+      string_only_paths = string_only_paths.map { |path| File.realpath(path) rescue File.expand_path(path) }.uniq
+      { paths: paths, issues: issues, string_only_paths: string_only_paths }
+    end
+
+    def appstore_payload_framework_dirs(executable_path:, app_dir:, main_frameworks_dir:)
+      dirs = [main_frameworks_dir]
+      cursor = File.dirname(executable_path)
+      while cursor.start_with?(File.expand_path(app_dir))
+        if File.basename(cursor).match?(/\.(?:app|appex|xpc)\z/)
+          dirs << File.join(cursor, 'Frameworks')
+          dirs << File.join(cursor, 'Contents', 'Frameworks')
+        end
+        parent = File.dirname(cursor)
+        break if parent == cursor
+
+        cursor = parent
+      end
+      dirs.compact.select { |path| Dir.exist?(path) }.uniq
+    end
+
+    def appstore_compiled_artifact_report(app_dir:, platform:, expected_bundle_id:, review_notes_blob:,
+                                          configured_product_id:, uses_storekit_unlock:)
+      issues = []
+      warnings = []
+      identity = appstore_select_submission_app(
+        app_dirs: [app_dir],
+        expected_bundle_ids: [expected_bundle_id],
+        platform: platform
+      )
+      return { verified: false, issues: identity[:issues], warnings: warnings } unless identity[:verified]
+
+      permission_plist_report = appstore_built_plist_permission_report(identity[:info_plist])
+      unless permission_plist_report[:verified]
+        return { verified: false, issues: permission_plist_report[:issues], warnings: warnings }
+      end
+
+      product_out, product_status = appstore_plistbuddy_capture('-c', 'Print :AppStoreProductID', identity[:info_plist])
+      built_product_id = product_status.success? ? product_out.to_s.strip : ''
+      unless product_status.success? || product_out.to_s.match?(/Does Not Exist/i)
+        issues << 'App Store artifact audit could not query AppStoreProductID from the built Info.plist'
+      end
+      if uses_storekit_unlock
+        if built_product_id.empty?
+          issues << 'Built App Store artifact is missing Info.plist key AppStoreProductID (StoreKit unlock flow detected)'
+        elsif !configured_product_id.to_s.empty? && built_product_id != configured_product_id.to_s
+          issues << "Built AppStoreProductID mismatch (expected #{configured_product_id}, got #{built_product_id})"
+        end
+      end
+
+      binary_path = File.join(identity[:layout][:executable_dir], identity[:executable])
+      unless File.file?(binary_path)
+        issues << "App Store artifact audit could not find app executable for #{expected_bundle_id}"
+        return { verified: false, issues: issues, warnings: warnings }
+      end
+
+      inventory = appstore_shipped_executable_inventory(
+        app_dir: app_dir,
+        platform: platform,
+        main_binary: binary_path
+      )
+      issues.concat(inventory[:issues])
+      inventory[:paths].each do |payload_path|
+        payload_label = payload_path.sub(%r{\A#{Regexp.escape(app_dir)}/?}, '')
+        canonical_payload_path = File.realpath(payload_path) rescue File.expand_path(payload_path)
+        string_only = Array(inventory[:string_only_paths]).include?(canonical_payload_path)
+        command_results = { strings: appstore_artifact_capture('strings', '-a', payload_path) }
+        unless string_only
+          command_results[:otool] = appstore_artifact_capture('otool', '-L', payload_path)
+          command_results[:nm] = appstore_artifact_capture('nm', '-m', payload_path)
+        end
+        command_results.each do |name, (_output, status)|
+          issues << "App Store artifact audit could not run #{name} on shipped executable #{payload_label}" unless status.success?
+        end
+        next unless command_results.values.all? { |_output, status| status.success? }
+
+        otool_out = command_results.dig(:otool, 0).to_s
+        strings_out = command_results[:strings][0].to_s
+        nm_out = command_results.dig(:nm, 0).to_s
+        framework_dirs = appstore_payload_framework_dirs(
+          executable_path: payload_path,
+          app_dir: app_dir,
+          main_frameworks_dir: identity[:layout][:frameworks_dir]
+        )
+        unresolved = otool_out.lines.drop(1).map(&:strip).reject(&:empty?).map do |line|
+          lib = line.split(' (').first.to_s.strip
+          next unless lib.start_with?('@rpath/')
+          next if line.include?(', weak)')
+
+          relative = lib.sub('@rpath/', '')
+          lib unless framework_dirs.any? { |dir| File.exist?(File.join(dir, relative)) }
+        end.compact
+        if unresolved.any?
+          issues << "App Store artifact has unresolved non-weak dylib references in #{payload_label}: #{unresolved.uniq.join(', ')}"
+        end
+
+        artifact_blob = [payload_path == binary_path ? permission_plist_report[:root_dump] : '', strings_out, nm_out, otool_out].join("\n")
+        direct_purchase_markers = appstore_direct_purchase_markers(artifact_blob, built_product_id: built_product_id)
+        if direct_purchase_markers.any?
+          issues << "Built App Store artifact still exposes direct-purchase markers in #{payload_label} (#{direct_purchase_markers.join(', ')})"
+        elsif artifact_blob.match?(%r{api\.lemonsqueezy\.com/v1/licenses/validate}i) && !built_product_id.empty?
+          warnings << "Built App Store artifact still contains LemonSqueezy license-validation strings in #{payload_label} — verify website-license code is unreachable in the App Store build"
+        end
+
+        donation_markers = appstore_donation_markers(artifact_blob)
+        if donation_markers.any?
+          issues << "Built App Store artifact still exposes donation/support markers in #{payload_label} (#{donation_markers.join(', ')})"
+        end
+
+        update_markers = appstore_update_markers(strings_out: strings_out, otool_out: otool_out)
+        if update_markers.any?
+          issues << "Built App Store artifact still exposes outside-update markers in #{payload_label} (#{update_markers.join(', ')})"
+        end
+
+        payload_declarations = if payload_path == binary_path
+                                 permission_plist_report[:declarations]
+                               else
+                                 { 'NSAccessibilityUsageDescription' => false, 'NSAppleEventsUsageDescription' => false }
+                               end
+        permission_findings = appstore_permission_artifact_findings(
+          review_notes_blob: payload_path == binary_path ? review_notes_blob : '',
+          declarations: payload_declarations,
+          artifact_blob: artifact_blob,
+          strings_out: strings_out,
+          nm_out: nm_out,
+          otool_out: otool_out,
+          payload_label: payload_label
+        )
+        issues.concat(permission_findings[:issues])
+        warnings.concat(permission_findings[:warnings])
+      end
+
+      launch_daemons_dir = identity[:layout][:launch_daemons_dir]
+      if launch_daemons_dir && Dir.exist?(launch_daemons_dir)
+        issues << 'Built App Store artifact still embeds LaunchDaemons payload — Mac App Store apps cannot ship launchd daemons or agents'
+      end
+
+      { verified: issues.empty?, issues: issues.uniq, warnings: warnings.uniq }
+    rescue StandardError => e
+      {
+        verified: false,
+        issues: ["Compiled App Store artifact audit failed unexpectedly: #{e.message}"],
+        warnings: warnings || []
+      }
+    end
+
     def image_edge_luminance_report(path)
       return nil unless path && File.file?(path)
 
@@ -2277,7 +2629,7 @@ module SaneMasterModules
       root_real = File.realpath(root)
       Array(paths).sort.map do |relative_path|
         next if relative_path == 'outputs/appstore_preflight_status.json'
-        next if relative_path.start_with?('.sanemaster/appstore-preflight-bindings/')
+        next if relative_path.start_with?('outputs/appstore-preflight-bindings/')
 
         absolute_path = File.expand_path(relative_path, root_real)
         unless absolute_path.start_with?("#{root_real}/")
@@ -2322,54 +2674,162 @@ module SaneMasterModules
       'unknown'
     end
 
-    def appstore_package_info(pkg_path)
-      read_plist = lambda do |info_path|
-        return nil unless info_path && File.file?(info_path)
+    def appstore_bundle_layout(app_dir, platform:)
+      if platform.to_s == 'ios'
+        {
+          info_plist: File.join(app_dir, 'Info.plist'),
+          executable_dir: app_dir,
+          frameworks_dir: File.join(app_dir, 'Frameworks'),
+          launch_daemons_dir: nil
+        }
+      else
+        contents = File.join(app_dir, 'Contents')
+        {
+          info_plist: File.join(contents, 'Info.plist'),
+          executable_dir: File.join(contents, 'MacOS'),
+          frameworks_dir: File.join(contents, 'Frameworks'),
+          launch_daemons_dir: File.join(contents, 'Library', 'LaunchDaemons')
+        }
+      end
+    end
 
-        values = %w[CFBundleIdentifier CFBundleShortVersionString CFBundleVersion].map do |key|
-          Open3.capture2('/usr/libexec/PlistBuddy', '-c', "Print :#{key}", info_path).first.to_s.strip
+    def appstore_bundle_identity_report(app_dir, platform:)
+      layout = appstore_bundle_layout(app_dir, platform: platform)
+      info_path = layout[:info_plist]
+      return { verified: false, issue: "App Store artifact is missing Info.plist: #{app_dir}" } unless File.file?(info_path)
+
+      values = {}
+      %w[CFBundleIdentifier CFBundleShortVersionString CFBundleVersion CFBundleExecutable].each do |key|
+        output, status = appstore_plistbuddy_capture('-c', "Print :#{key}", info_path)
+        value = output.to_s.strip
+        unless status.success? && !value.empty?
+          return { verified: false, issue: "App Store artifact could not read #{key} from #{info_path}" }
         end
-        return nil if values.any?(&:empty?)
+        values[key] = value
+      end
+      {
+        verified: true,
+        app_dir: app_dir,
+        info_plist: info_path,
+        bundle_id: values['CFBundleIdentifier'],
+        version: values['CFBundleShortVersionString'],
+        build: values['CFBundleVersion'],
+        executable: values['CFBundleExecutable'],
+        layout: layout
+      }
+    rescue StandardError => e
+      { verified: false, issue: "App Store artifact identity inspection failed for #{app_dir}: #{e.message}" }
+    end
 
-        { bundle_id: values[0], version: values[1], build: values[2] }
+    def appstore_select_submission_app(app_dirs:, expected_bundle_ids:, platform:)
+      expected = Array(expected_bundle_ids).map(&:to_s).reject(&:empty?).uniq
+      if expected.empty?
+        return { verified: false, issues: ['Cannot resolve the expected App Store bundle ID for exact artifact selection'] }
       end
 
-      Dir.mktmpdir('sanemaster_appstore_binding') do |tmpdir|
-        if pkg_path.end_with?('.ipa')
-          return nil unless system(
-            'unzip', '-qq', '-o', pkg_path, 'Payload/*.app/Info.plist', '-d', tmpdir,
-            out: File::NULL, err: File::NULL
-          )
+      candidates = Array(app_dirs).uniq.sort.map do |app_dir|
+        appstore_bundle_identity_report(app_dir, platform: platform)
+      end
+      matches = candidates.select { |candidate| candidate[:verified] && expected.include?(candidate[:bundle_id]) }
+      if matches.length != 1
+        discovered = candidates.select { |candidate| candidate[:verified] }.map { |candidate| candidate[:bundle_id] }.uniq
+        detail = discovered.empty? ? 'none with readable identity' : discovered.join(', ')
+        issue = if matches.empty?
+                  "Exact App Store artifact not found for bundle ID #{expected.join(' or ')} (found: #{detail})"
+                else
+                  "App Store artifact selection is ambiguous for bundle ID #{matches.first[:bundle_id]} (#{matches.length} matches)"
+                end
+        identity_issues = candidates.reject { |candidate| candidate[:verified] }.map { |candidate| candidate[:issue] }
+        return { verified: false, issues: [issue, *identity_issues].compact }
+      end
 
-          return read_plist.call(Dir.glob(File.join(tmpdir, 'Payload', '*.app', 'Info.plist')).first)
+      matches.first.merge(issues: [])
+    end
+
+    def appstore_pkg_top_level_app_dirs(expanded_dir)
+      Dir.glob(File.join(expanded_dir, '**', 'Payload', '**', '*.app')).select do |path|
+        relative = path.split('/Payload/', 2)[1].to_s
+        parents = relative.split('/')[0...-1]
+        parents.none? { |component| component.end_with?('.app') }
+      end.uniq.sort
+    end
+
+    def appstore_with_submission_package_app(pkg_path, expected_bundle_ids:, expected_sha256: nil)
+      platform = if pkg_path.end_with?('.ipa')
+                   'ios'
+                 elsif pkg_path.end_with?('.pkg')
+                   'macos'
+                 end
+      unless platform
+        return yield(verified: false, issues: ["Unsupported App Store package type: #{pkg_path}"])
+      end
+
+      digest_before = OpenSSL::Digest::SHA256.file(pkg_path).hexdigest
+      if expected_sha256 && digest_before != expected_sha256.to_s
+        return yield(verified: false, issues: ['Exact App Store package bytes do not match the bound submissionTarget.sha256'])
+      end
+
+      Dir.mktmpdir('sanemaster_appstore_package_audit') do |tmpdir|
+        extraction_issue = nil
+        app_dirs = begin
+          if platform == 'ios'
+            extracted = system('unzip', '-qq', '-o', pkg_path, '-d', tmpdir, out: File::NULL, err: File::NULL)
+            extraction_issue = "Could not extract exact iOS submission package: #{pkg_path}" unless extracted
+            extracted ? Dir.glob(File.join(tmpdir, 'Payload', '*.app')) : []
+          else
+            expanded = File.join(tmpdir, 'expanded')
+            extracted = system('pkgutil', '--expand-full', pkg_path, expanded, out: File::NULL, err: File::NULL)
+            extraction_issue = "Could not extract exact macOS submission package: #{pkg_path}" unless extracted
+            extracted ? appstore_pkg_top_level_app_dirs(expanded) : []
+          end
+        rescue StandardError => e
+          extraction_issue = "Exact App Store package extraction failed: #{e.message}"
+          []
+        end
+        return yield(verified: false, issues: [extraction_issue]) if extraction_issue
+
+        digest_after = OpenSSL::Digest::SHA256.file(pkg_path).hexdigest
+        unless digest_after == digest_before && (!expected_sha256 || digest_after == expected_sha256.to_s)
+          return yield(verified: false, issues: ['Exact App Store package changed while it was being extracted for audit'])
         end
 
-        return nil unless pkg_path.end_with?('.pkg')
-
-        expanded = File.join(tmpdir, 'expanded')
-        return nil unless system('pkgutil', '--expand-full', pkg_path, expanded, out: File::NULL, err: File::NULL)
-
-        candidates = Dir.glob(File.join(expanded, '**', 'Payload', '*.app', 'Contents', 'Info.plist'))
-        info_path = candidates.find { |candidate| !candidate.include?('/Frameworks/') && !candidate.include?('/PlugIns/') } || candidates.first
-        read_plist.call(info_path)
+        selection = appstore_select_submission_app(
+          app_dirs: app_dirs,
+          expected_bundle_ids: expected_bundle_ids,
+          platform: platform
+        )
+        yield selection.merge(platform: platform)
       end
+    end
+
+    def appstore_package_info(pkg_path, expected_bundle_ids:, expected_sha256: nil)
+      result = nil
+      appstore_with_submission_package_app(
+        pkg_path,
+        expected_bundle_ids: expected_bundle_ids,
+        expected_sha256: expected_sha256
+      ) do |selection|
+        @appstore_package_info_issues = Array(selection[:issues])
+        if selection[:verified]
+          result = {
+            bundle_id: selection[:bundle_id],
+            version: selection[:version],
+            build: selection[:build]
+          }
+        end
+      end
+      result
     end
 
     def appstore_preflight_submission_target(args:, version:, build:, platforms:, issues:)
       options = {}
       parser = OptionParser.new do |opts|
         opts.on('--pkg PATH') { |value| options[:pkg] = value }
-        opts.on('--asc-build-id ID') { |value| options[:asc_build_id] = value }
-        opts.on('--build-number NUMBER') { |value| options[:build] = value }
         opts.on('--platform PLATFORM') { |value| options[:platform] = value.to_s.downcase }
       end
       parser.parse!(Array(args).dup)
 
-      if options[:pkg] && options[:asc_build_id]
-        issues << 'App Store preflight submission binding cannot target both a package and an existing ASC build'
-        return nil
-      end
-      return nil unless options[:pkg] || options[:asc_build_id]
+      return nil unless options[:pkg]
 
       platform = options[:platform].to_s
       if platform.empty? || !Array(platforms).map { |item| item.to_s.downcase }.include?(platform)
@@ -2384,21 +2844,34 @@ module SaneMasterModules
           return nil
         end
 
-        info = appstore_package_info(path)
-        unless info
-          issues << "Could not extract bundle identity from App Store submission package: #{path}"
-          return nil
-        end
-        issues << "Submission package version #{info[:version]} does not match preflight version #{version}" unless info[:version].to_s == version.to_s
-        issues << "Submission package build #{info[:build]} does not match preflight build #{build}" unless info[:build].to_s == build.to_s
-        expected_platform = path.end_with?('.ipa') ? 'ios' : (path.end_with?('.pkg') ? 'macos' : '')
-        issues << "Submission package type does not match platform #{platform}" unless expected_platform == platform
         signing_targets = if platform == 'macos'
                             appstore_macos_signing_targets(File.join(Dir.pwd, 'project.yml'))
                           else
                             appstore_mobile_signing_targets(File.join(Dir.pwd, 'project.yml'))
                           end
         expected_bundle_ids = Array(signing_targets).map { |target| target[:bundle_id].to_s }.reject(&:empty?).uniq
+        if expected_bundle_ids.empty?
+          issues << "Cannot resolve an App Store target bundle ID for package inspection on #{platform}"
+          return nil
+        end
+
+        package_sha256 = OpenSSL::Digest::SHA256.file(path).hexdigest
+        info = appstore_package_info(
+          path,
+          expected_bundle_ids: expected_bundle_ids,
+          expected_sha256: package_sha256
+        )
+        unless info
+          detail = Array(@appstore_package_info_issues).join('; ')
+          message = "Could not extract a unique expected bundle identity from App Store submission package: #{path}"
+          message += " (#{detail})" unless detail.empty?
+          issues << message
+          return nil
+        end
+        issues << "Submission package version #{info[:version]} does not match preflight version #{version}" unless info[:version].to_s == version.to_s
+        issues << "Submission package build #{info[:build]} does not match preflight build #{build}" unless info[:build].to_s == build.to_s
+        expected_platform = path.end_with?('.ipa') ? 'ios' : (path.end_with?('.pkg') ? 'macos' : '')
+        issues << "Submission package type does not match platform #{platform}" unless expected_platform == platform
         if expected_bundle_ids.any? && !expected_bundle_ids.include?(info[:bundle_id].to_s)
           issues << "Submission package bundle ID #{info[:bundle_id]} is not an App Store target bundle ID (expected #{expected_bundle_ids.join(', ')})"
         end
@@ -2407,27 +2880,14 @@ module SaneMasterModules
           type: 'package',
           platform: platform,
           fileName: File.basename(path),
-          sha256: OpenSSL::Digest::SHA256.file(path).hexdigest,
+          sha256: package_sha256,
           size: File.size(path),
           bundleId: info[:bundle_id],
           version: info[:version],
-          build: info[:build]
+          build: info[:build],
+          path: path
         }
       end
-
-      requested_build = options[:build].to_s
-      if options[:asc_build_id].to_s.empty? || requested_build.empty?
-        issues << 'Existing ASC build binding requires both --asc-build-id and --build-number'
-        return nil
-      end
-      issues << "Existing ASC build #{requested_build} does not match preflight build #{build}" unless requested_build == build.to_s
-      {
-        type: 'asc_build',
-        platform: platform,
-        ascBuildId: options[:asc_build_id].to_s,
-        version: version.to_s,
-        build: requested_build
-      }
     rescue OptionParser::ParseError => e
       issues << "Invalid App Store preflight submission binding: #{e.message}"
       nil
@@ -2443,7 +2903,7 @@ module SaneMasterModules
         version: version.to_s,
         build: build.to_s,
         platforms: Array(platforms).map(&:to_s),
-        submissionTarget: submission_target,
+        submissionTarget: submission_target&.reject { |key, _value| key.to_s == 'path' },
         worktreeFingerprint: appstore_worktree_fingerprint(root: Dir.pwd),
         status: status,
         issueCount: issues.count,
@@ -5670,15 +6130,58 @@ module SaneMasterModules
 
       # 5h. Build App Store config and audit resulting artifact for runtime blockers
       print '  │ Compiled App Store artifact audit... '
-      if platforms.include?('macos')
-        compiled_artifact_verified_clean = false
-        begin
+      compiled_artifact_verified_clean = false
+      artifact_report = nil
+      begin
+        if submission_target && submission_target[:path]
+          package_path = submission_target[:path].to_s
+          actual_sha = File.file?(package_path) ? OpenSSL::Digest::SHA256.file(package_path).hexdigest : ''
+          if actual_sha != submission_target[:sha256].to_s
+            artifact_report = {
+              verified: false,
+              issues: ['Exact App Store package bytes changed after submissionTarget binding; rerun preflight for the selected package'],
+              warnings: []
+            }
+          else
+            appstore_with_submission_package_app(
+              package_path,
+              expected_bundle_ids: [submission_target[:bundleId]],
+              expected_sha256: submission_target[:sha256]
+            ) do |selection|
+              artifact_report = if selection[:verified]
+                                  appstore_compiled_artifact_report(
+                                    app_dir: selection[:app_dir],
+                                    platform: selection[:platform],
+                                    expected_bundle_id: submission_target[:bundleId],
+                                    review_notes_blob: review_notes_blob,
+                                    configured_product_id: configured_product_id,
+                                    uses_storekit_unlock: uses_storekit_unlock
+                                  )
+                                else
+                                  { verified: false, issues: selection[:issues], warnings: [] }
+                                end
+            end
+          end
+        elsif platforms.include?('macos')
           Dir.mktmpdir('sanemaster_asc_audit') do |tmpdir|
             derived_data = File.join(tmpdir, 'DerivedData')
             configuration = (asc_config_name || appstore_config['configuration'] || 'Release-AppStore').to_s
             scheme = (appstore_config['scheme'] || config['scheme'] || app_name).to_s
             workspace = config['workspace']
             project = config['project'] || Dir.glob('*.xcodeproj').first
+            signing_targets = appstore_macos_signing_targets(project_yml)
+            named_targets = signing_targets.select { |target| target[:name].to_s == scheme }
+            expected_bundle_ids = (named_targets.empty? ? signing_targets : named_targets)
+              .map { |target| target[:bundle_id].to_s }.reject(&:empty?).uniq
+
+            if expected_bundle_ids.length != 1
+              artifact_report = {
+                verified: false,
+                issues: ["Cannot resolve one exact App Store bundle ID for scheme #{scheme} (found: #{expected_bundle_ids.join(', ')})"],
+                warnings: []
+              }
+              next
+            end
 
             build_cmd = ['xcodebuild']
             if workspace && File.exist?(workspace)
@@ -5686,17 +6189,12 @@ module SaneMasterModules
             elsif project && File.exist?(project)
               build_cmd += ['-project', project]
             else
-              puts '❌ project/workspace not found'
-              issues << 'Cannot run compiled App Store artifact audit: missing workspace/project path'
-              break
+              artifact_report = { verified: false, issues: ['Cannot run compiled App Store artifact audit: missing workspace/project path'], warnings: [] }
+              next
             end
             build_cmd += [
-              '-scheme', scheme,
-              '-configuration', configuration,
-              '-destination', 'platform=macOS',
-              '-derivedDataPath', derived_data,
-              'CODE_SIGNING_ALLOWED=NO',
-              'build'
+              '-scheme', scheme, '-configuration', configuration, '-destination', 'platform=macOS',
+              '-derivedDataPath', derived_data, 'CODE_SIGNING_ALLOWED=NO', 'build'
             ]
             effective_build_flags = Array(appstore_config['build_flags']).map(&:to_s).reject(&:empty?)
             unless configured_product_id.empty? || effective_build_flags.any? { |flag| flag.start_with?('INFOPLIST_KEY_AppStoreProductID=') }
@@ -5704,140 +6202,56 @@ module SaneMasterModules
             end
             build_cmd.concat(effective_build_flags)
             build_cmd.concat(Array(appstore_config['archive_extra_args']).map(&:to_s).reject(&:empty?))
-
             build_out, build_status = Open3.capture2e(*build_cmd)
             unless build_status.success?
-              puts '❌ build failed'
               hint = summarized_output_tail(build_out)
-              puts "  │   ↳ #{hint}" unless hint.empty?
-              issues << "App Store artifact audit build failed for configuration #{configuration}"
+              message = "App Store artifact audit build failed for configuration #{configuration}"
+              message += ": #{hint}" unless hint.empty?
+              artifact_report = { verified: false, issues: [message], warnings: [] }
               next
             end
 
-            app_dir = Dir.glob(File.join(derived_data, 'Build', 'Products', configuration, '*.app'))
-              .reject { |p| p.include?('.appex/') }.first
-            if app_dir.nil?
-              puts '❌ built app missing'
-              issues << "App Store artifact audit could not find built .app under #{configuration}"
-              next
-            end
-
-            info_plist = File.join(app_dir, 'Contents', 'Info.plist')
-            plist_dump = File.read(info_plist) rescue ''
-            executable, = Open3.capture2('/usr/libexec/PlistBuddy', '-c', 'Print :CFBundleExecutable', info_plist)
-            executable = executable.to_s.strip
-            binary_path = File.join(app_dir, 'Contents', 'MacOS', executable)
-            built_product_id, = Open3.capture2('/usr/libexec/PlistBuddy', '-c', 'Print :AppStoreProductID', info_plist)
-            built_product_id = built_product_id.to_s.strip
-            if uses_storekit_unlock
-              if built_product_id.empty?
-                issues << 'Built App Store artifact is missing Info.plist key AppStoreProductID (StoreKit unlock flow detected)'
-              elsif !configured_product_id.empty? && built_product_id != configured_product_id
-                issues << "Built AppStoreProductID mismatch (expected #{configured_product_id}, got #{built_product_id})"
-              end
-            end
-
-            if File.file?(binary_path)
-              otool_out, = Open3.capture2('otool', '-L', binary_path)
-              strings_out, = Open3.capture2('strings', '-a', binary_path)
-              nm_out, = Open3.capture2('nm', '-m', binary_path)
-              dylib_lines = otool_out.lines.drop(1).map(&:strip).reject(&:empty?)
-              unresolved = []
-
-              dylib_lines.each do |line|
-                lib = line.split(' (').first.to_s.strip
-                next unless lib.start_with?('@rpath/')
-                next if line.include?(', weak)')
-
-                rel = lib.sub('@rpath/', '')
-                candidate = File.join(app_dir, 'Contents', 'Frameworks', rel)
-                unresolved << lib unless File.exist?(candidate)
-              end
-
-              sparkle_framework = File.join(app_dir, 'Contents', 'Frameworks', 'Sparkle.framework')
-              sparkle_ref = dylib_lines.find { |line| line.include?('@rpath/Sparkle.framework') }
-              if sparkle_ref && !sparkle_ref.include?(', weak)') && !File.exist?(sparkle_framework)
-                unresolved << '@rpath/Sparkle.framework/Versions/B/Sparkle'
-              end
-
-              if unresolved.any?
-                puts "❌ unresolved dylibs (#{unresolved.uniq.count})"
-                issues << "App Store artifact has unresolved non-weak dylib references: #{unresolved.uniq.join(', ')}"
-              else
-                artifact_blob = [plist_dump, strings_out, nm_out, otool_out].join("\n")
-                artifact_issues = []
-                artifact_warnings = []
-                launch_daemons_dir = File.join(app_dir, 'Contents', 'Library', 'LaunchDaemons')
-
-                if Dir.exist?(launch_daemons_dir)
-                  artifact_issues << 'Built App Store artifact still embeds LaunchDaemons payload — Mac App Store apps cannot ship launchd daemons or agents'
-                end
-
-                direct_purchase_markers = appstore_direct_purchase_markers(artifact_blob, built_product_id: built_product_id)
-                if direct_purchase_markers.any?
-                  artifact_issues << "Built App Store artifact still exposes direct-purchase markers (#{direct_purchase_markers.join(', ')})"
-                elsif artifact_blob.match?(%r{api\.lemonsqueezy\.com/v1/licenses/validate}i) && !built_product_id.empty?
-                  artifact_warnings << 'Built App Store artifact still contains LemonSqueezy license-validation strings — verify website-license code is unreachable in the App Store build'
-                end
-
-                donation_markers = appstore_donation_markers(artifact_blob)
-                if donation_markers.any?
-                  artifact_issues << "Built App Store artifact still exposes donation/support markers (#{donation_markers.join(', ')})"
-                end
-
-                update_markers = appstore_update_markers(strings_out: strings_out, otool_out: otool_out)
-                if update_markers.any?
-                  artifact_issues << "Built App Store artifact still exposes outside-update markers (#{update_markers.join(', ')})"
-                end
-
-                if review_notes_blob.match?(/does not request accessibility/i) &&
-                   artifact_blob.include?('NSAccessibilityUsageDescription')
-                  artifact_issues << 'Review notes claim no Accessibility request, but built Info.plist still declares NSAccessibilityUsageDescription'
-                end
-
-                if review_notes_blob.match?(/does not request.*apple events|no apple events/i) &&
-                   artifact_blob.include?('NSAppleEventsUsageDescription')
-                  artifact_issues << 'Review notes claim no Apple Events request, but built Info.plist still declares NSAppleEventsUsageDescription'
-                end
-
-                accessibility_markers = []
-                accessibility_markers << 'ApplicationServices linkage' if otool_out.include?('ApplicationServices.framework')
-                accessibility_markers << 'AXIsProcessTrusted symbol' if nm_out.match?(/_AXIsProcessTrusted/)
-                accessibility_markers << 'Accessibility settings deep link' if strings_out.include?('Privacy_Accessibility')
-                if accessibility_markers.any?
-                  artifact_issues << "Built App Store artifact still contains Accessibility markers (#{accessibility_markers.join(', ')})"
-                end
-
-                apple_events_markers = []
-                apple_events_markers << 'osascript runtime' if artifact_blob.include?('/usr/bin/osascript')
-                apple_events_markers << 'Apple Events usage description' if artifact_blob.include?('NSAppleEventsUsageDescription')
-                if apple_events_markers.any?
-                  artifact_warnings << "Built App Store artifact still contains Apple Events markers (#{apple_events_markers.join(', ')}) — verify App Review notes and App Store policy fit"
-                end
-
-                if artifact_issues.empty?
-                  puts '✅'
-                  compiled_artifact_verified_clean = true
-                else
-                  puts "❌ #{artifact_issues.first}"
-                  artifact_issues.each { |msg| issues << msg }
-                end
-                artifact_warnings.each { |msg| warnings << msg }
-              end
-            else
-              puts '❌ executable missing'
-              issues << 'App Store artifact audit could not find app executable'
-            end
+            candidates = Dir.glob(File.join(derived_data, 'Build', 'Products', configuration, '*.app'))
+            selection = appstore_select_submission_app(
+              app_dirs: candidates,
+              expected_bundle_ids: expected_bundle_ids,
+              platform: 'macos'
+            )
+            artifact_report = if selection[:verified]
+                                appstore_compiled_artifact_report(
+                                  app_dir: selection[:app_dir], platform: 'macos',
+                                  expected_bundle_id: expected_bundle_ids.first,
+                                  review_notes_blob: review_notes_blob,
+                                  configured_product_id: configured_product_id,
+                                  uses_storekit_unlock: uses_storekit_unlock
+                                )
+                              else
+                                { verified: false, issues: selection[:issues], warnings: [] }
+                              end
           end
-        rescue StandardError => e
-          puts "⚠️  audit error: #{e.message}"
-          warnings << "Compiled App Store artifact audit failed unexpectedly: #{e.message}"
+        else
+          puts '⏭️  skipped (unbound non-macOS diagnostic)'
         end
+      rescue StandardError => e
+        artifact_report = {
+          verified: false,
+          issues: ["Compiled App Store artifact audit failed unexpectedly: #{e.message}"],
+          warnings: []
+        }
+      end
+
+      if artifact_report
+        compiled_artifact_verified_clean = artifact_report[:verified] == true
         if compiled_artifact_verified_clean
-          warnings.delete('Policy guard: Source contains clipboard automation for non-App-Store builds, but the App Store build script strips automation usage descriptions and review notes describe manual paste. Verify the compiled App Store artifact before blocking submission.')
+          puts '✅'
+        else
+          puts "❌ #{artifact_report[:issues].first}"
+          Array(artifact_report[:issues]).each { |msg| issues << msg }
         end
-      else
-        puts '⏭️  skipped (non-macOS submission)'
+        Array(artifact_report[:warnings]).each { |msg| warnings << msg }
+      end
+      if compiled_artifact_verified_clean
+        warnings.delete('Policy guard: Source contains clipboard automation for non-App-Store builds, but the App Store build script strips automation usage descriptions and review notes describe manual paste. Verify the compiled App Store artifact before blocking submission.')
       end
 
       # 5h. No DEBUG/development code leaking into release

--- a/scripts/sanemaster/release_guardrail_test.rb
+++ b/scripts/sanemaster/release_guardrail_test.rb
@@ -131,6 +131,51 @@ def write_test_png_with_text(path, text:, source: 'outputs/shared-source.png', w
   )
 end
 
+def write_artifact_test_app(root, name:, bundle_id:, platform: 'macos', executable_text: 'clean artifact')
+  app_dir = File.join(root, "#{name}.app")
+  if platform == 'ios'
+    info_path = File.join(app_dir, 'Info.plist')
+    binary_path = File.join(app_dir, name)
+  else
+    info_path = File.join(app_dir, 'Contents', 'Info.plist')
+    binary_path = File.join(app_dir, 'Contents', 'MacOS', name)
+  end
+  FileUtils.mkdir_p(File.dirname(binary_path))
+  File.write(
+    info_path,
+    <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0"><dict>
+        <key>CFBundleIdentifier</key><string>#{bundle_id}</string>
+        <key>CFBundleShortVersionString</key><string>1.0</string>
+        <key>CFBundleVersion</key><string>100</string>
+        <key>CFBundleExecutable</key><string>#{name}</string>
+      </dict></plist>
+    PLIST
+  )
+  File.write(binary_path, executable_text)
+  app_dir
+end
+
+def write_artifact_test_extension(root, name:, bundle_id:, executable_text: 'clean extension')
+  bundle_dir = File.join(root, "#{name}.appex")
+  binary_path = File.join(bundle_dir, name)
+  FileUtils.mkdir_p(bundle_dir)
+  File.write(
+    File.join(bundle_dir, 'Info.plist'),
+    <<~PLIST
+      <?xml version="1.0" encoding="UTF-8"?>
+      <plist version="1.0"><dict>
+        <key>CFBundleIdentifier</key><string>#{bundle_id}</string>
+        <key>CFBundleExecutable</key><string>#{name}</string>
+      </dict></plist>
+    PLIST
+  )
+  File.write(binary_path, executable_text)
+  bundle_dir
+end
+
 def write_resource_soak_pair(dir, version:, build:, include_log: true, keyword_candidate: false)
   now = Time.now.utc
   evidence_dir = File.join(dir, 'outputs', 'customer-ui', 'resource-soak-proof')
@@ -4662,35 +4707,6 @@ exit(run_tests('SaneMaster App Store Guardrail Tests') do
       true
     end
 
-    test('appstore preflight binds an exact ASC build and rejects build-number drift') do
-      issues = []
-      target = subject.send(
-        :appstore_preflight_submission_target,
-        args: ['--platform', 'ios', '--asc-build-id', 'build-123', '--build-number', '100'],
-        version: '1.0',
-        build: '100',
-        platforms: ['ios'],
-        issues: issues
-      )
-
-      assert_eq(issues, [])
-      assert_eq(target[:type], 'asc_build')
-      assert_eq(target[:ascBuildId], 'build-123')
-      assert_eq(target[:build], '100')
-
-      drift_issues = []
-      subject.send(
-        :appstore_preflight_submission_target,
-        args: ['--platform', 'ios', '--asc-build-id', 'build-123', '--build-number', '101'],
-        version: '1.0',
-        build: '100',
-        platforms: ['ios'],
-        issues: drift_issues
-      )
-      assert(drift_issues.any? { |issue| issue.include?('does not match preflight build') })
-      true
-    end
-
     test('appstore package binding rejects a package from another bundle target') do
       Dir.mktmpdir('appstore-package-target-') do |dir|
         File.write(
@@ -4712,7 +4728,8 @@ exit(run_tests('SaneMaster App Store Guardrail Tests') do
         binding_subject = Class.new(ReleaseGuardrailHarness) do
           attr_accessor :stub_package_bundle_id
 
-          def appstore_package_info(_path)
+          def appstore_package_info(_path, expected_bundle_ids:, expected_sha256: nil)
+            _ = [expected_bundle_ids, expected_sha256]
             { bundle_id: stub_package_bundle_id, version: '1.0', build: '100' }
           end
         end.new
@@ -6591,6 +6608,373 @@ exit(run_tests('SaneMaster App Store Guardrail Tests') do
   end
 
   test_category('Artifact marker detection') do
+    test('selects the exact submitted app by bundle ID instead of the first helper app') do
+      Dir.mktmpdir('artifact-exact-app-selection-') do |dir|
+        helper = write_artifact_test_app(dir, name: 'AHelper', bundle_id: 'com.example.helper')
+        submitted = write_artifact_test_app(dir, name: 'ZSubmitted', bundle_id: 'com.example.submitted')
+
+        selection = subject.send(
+          :appstore_select_submission_app,
+          app_dirs: [helper, submitted],
+          expected_bundle_ids: ['com.example.submitted'],
+          platform: 'macos'
+        )
+
+        assert_eq(selection[:verified], true)
+        assert_eq(selection[:app_dir], submitted)
+      end
+      true
+    end
+
+    test('discovers a pkg app below its install root without treating nested helpers as products') do
+      Dir.mktmpdir('artifact-pkg-layout-') do |dir|
+        payload = File.join(dir, 'component', 'Payload', 'Applications')
+        submitted = write_artifact_test_app(payload, name: 'Submitted', bundle_id: 'com.example.submitted')
+        nested_root = File.join(submitted, 'Contents', 'Helpers')
+        write_artifact_test_app(nested_root, name: 'NestedHelper', bundle_id: 'com.example.helper')
+
+        candidates = subject.send(:appstore_pkg_top_level_app_dirs, dir)
+
+        assert_eq(candidates, [submitted])
+      end
+      true
+    end
+
+    test('blocks ambiguous and unreadable exact artifact identities') do
+      Dir.mktmpdir('artifact-identity-failure-') do |dir|
+        first = write_artifact_test_app(dir, name: 'First', bundle_id: 'com.example.submitted')
+        second = write_artifact_test_app(dir, name: 'Second', bundle_id: 'com.example.submitted')
+        ambiguous = subject.send(
+          :appstore_select_submission_app,
+          app_dirs: [first, second],
+          expected_bundle_ids: ['com.example.submitted'],
+          platform: 'macos'
+        )
+        assert_eq(ambiguous[:verified], false)
+        assert_includes(ambiguous[:issues].join("\n"), 'ambiguous')
+
+        File.write(File.join(first, 'Contents', 'Info.plist'), 'not a plist')
+        unreadable = subject.send(
+          :appstore_select_submission_app,
+          app_dirs: [first],
+          expected_bundle_ids: ['com.example.submitted'],
+          platform: 'macos'
+        )
+        assert_eq(unreadable[:verified], false)
+        assert_includes(unreadable[:issues].join("\n"), 'could not read CFBundleIdentifier')
+      end
+      true
+    end
+
+    test('audits forbidden markers from the exact package artifact instead of a clean rebuild') do
+      Dir.mktmpdir('artifact-package-vs-rebuild-') do |dir|
+        clean_app = write_artifact_test_app(dir, name: 'CleanBuild', bundle_id: 'com.example.app')
+        package_app = write_artifact_test_app(
+          dir,
+          name: 'SubmittedPackage',
+          bundle_id: 'com.example.app',
+          executable_text: 'https://go.saneapps.com/buy/example'
+        )
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          output = case command.first
+                   when 'strings' then File.read(command.last)
+                   when 'otool' then "#{command.last}:\n"
+                   else ''
+                   end
+          [output, success_status]
+        end
+
+        clean_report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: clean_app,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.app',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        package_report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: package_app,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.app',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+
+        assert_eq(clean_report[:verified], true)
+        assert_eq(package_report[:verified], false)
+        assert_includes(package_report[:issues].join("\n"), 'direct-purchase markers')
+      end
+      true
+    end
+
+    test('audits an exact iOS app bundle layout') do
+      Dir.mktmpdir('artifact-ios-layout-') do |dir|
+        ios_app = write_artifact_test_app(dir, name: 'SaneIOS', bundle_id: 'com.example.ios', platform: 'ios')
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          [command.first == 'otool' ? "#{command.last}:\n" : '', success_status]
+        end
+
+        report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: ios_app,
+          platform: 'ios',
+          expected_bundle_id: 'com.example.ios',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+
+        assert_eq(report[:verified], true)
+      end
+      true
+    end
+
+    test('audits recognized embedded helper apps but ignores arbitrary resource decoys') do
+      Dir.mktmpdir('artifact-embedded-helper-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'MainApp', bundle_id: 'com.example.main')
+        helpers_root = File.join(app_dir, 'Contents', 'Helpers')
+        helper_dir = write_artifact_test_app(
+          helpers_root,
+          name: 'BadHelper',
+          bundle_id: 'com.example.helper',
+          executable_text: 'https://go.saneapps.com/buy/example'
+        )
+        resource = File.join(app_dir, 'Contents', 'Resources', 'checkout-decoy.txt')
+        FileUtils.mkdir_p(File.dirname(resource))
+        File.write(resource, 'https://go.saneapps.com/buy/resource-decoy')
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          output = command.first == 'otool' ? "#{command.last}:\n" : File.read(command.last)
+          [output, success_status]
+        end
+
+        blocked = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.main',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        assert_eq(blocked[:verified], false)
+        assert_includes(blocked[:issues].join("\n"), 'BadHelper.app/Contents/MacOS/BadHelper')
+        assert_includes(blocked[:issues].join("\n"), 'direct-purchase markers')
+
+        File.write(File.join(helper_dir, 'Contents', 'MacOS', 'BadHelper'), 'clean helper')
+        clean = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.main',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        assert_eq(clean[:verified], true, 'resource-only marker decoy must not be treated as shipped executable code')
+      end
+      true
+    end
+
+    test('audits bare Mach-O helpers and dylibs inside embedded bundle Frameworks') do
+      Dir.mktmpdir('artifact-bare-helper-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'MainApp', bundle_id: 'com.example.main')
+        helpers_root = File.join(app_dir, 'Contents', 'Helpers')
+        embedded = write_artifact_test_app(
+          helpers_root,
+          name: 'EmbeddedHelper',
+          bundle_id: 'com.example.embedded'
+        )
+        bare_helper = File.join(helpers_root, 'BareMachO')
+        File.binwrite(bare_helper, "\xCF\xFA\xED\xFE".b + 'https://go.saneapps.com/buy/bare')
+        nested_dylib = File.join(embedded, 'Contents', 'Frameworks', 'Hidden.dylib')
+        FileUtils.mkdir_p(File.dirname(nested_dylib))
+        File.write(nested_dylib, 'Sponsor on GitHub')
+        resource_script = File.join(app_dir, 'Contents', 'Resources', 'looks-executable.sh')
+        FileUtils.mkdir_p(File.dirname(resource_script))
+        File.write(resource_script, "#!/bin/sh\nhttps://go.saneapps.com/buy/ignored\n")
+        File.chmod(0o755, resource_script)
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          output = if command.first == 'otool'
+                     "#{command.last}:\n"
+                   elsif command.first == 'strings' && command.last == bare_helper
+                     File.binread(command.last).byteslice(4..-1)
+                   elsif command.first == 'strings'
+                     File.read(command.last)
+                   else
+                     ''
+                   end
+          [output, success_status]
+        end
+
+        report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.main',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        joined = report[:issues].join("\n")
+        assert_includes(joined, 'Contents/Helpers/BareMachO')
+        assert_includes(joined, 'Hidden.dylib')
+        assert(!joined.include?('looks-executable.sh'), 'resource scripts must stay outside executable inventory')
+      end
+      true
+    end
+
+    test('audits runnable helper scripts in code roots while ignoring Resources scripts') do
+      Dir.mktmpdir('artifact-runnable-helper-script-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'MainApp', bundle_id: 'com.example.main')
+        executable_helper = File.join(app_dir, 'Contents', 'Helpers', 'checkout-helper')
+        shebang_helper = File.join(app_dir, 'Contents', 'Helpers', 'support-helper.sh')
+        resource_script = File.join(app_dir, 'Contents', 'Resources', 'ignored-helper.sh')
+        FileUtils.mkdir_p(File.dirname(executable_helper))
+        FileUtils.mkdir_p(File.dirname(resource_script))
+        File.write(executable_helper, 'https://go.saneapps.com/buy/helper')
+        File.chmod(0o755, executable_helper)
+        File.write(shebang_helper, "#!/bin/sh\nSponsor on GitHub\n")
+        File.chmod(0o644, shebang_helper)
+        File.write(resource_script, "#!/bin/sh\nhttps://go.saneapps.com/buy/ignored\n")
+        File.chmod(0o755, resource_script)
+
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          output = command.first == 'strings' ? File.read(command.last) : "#{command.last}:\n"
+          [output, success_status]
+        end
+
+        report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.main',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        joined = report[:issues].join("\n")
+        assert_eq(report[:verified], false)
+        assert_includes(joined, 'Contents/Helpers/checkout-helper')
+        assert_includes(joined, 'direct-purchase markers')
+        assert_includes(joined, 'Contents/Helpers/support-helper.sh')
+        assert_includes(joined, 'donation/support markers')
+        assert(!joined.include?('ignored-helper.sh'), 'Resources scripts must remain outside executable inventory')
+      end
+      true
+    end
+
+    test('fails closed when a recognized framework has no supported Info.plist') do
+      Dir.mktmpdir('artifact-framework-missing-plist-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'MainIOS', bundle_id: 'com.example.ios', platform: 'ios')
+        framework_dir = File.join(app_dir, 'Frameworks', 'Missing.framework')
+        framework_binary = File.join(framework_dir, 'Missing')
+        FileUtils.mkdir_p(framework_dir)
+        File.write(framework_binary, 'clean framework binary')
+
+        inventory = ReleaseGuardrailHarness.new.send(
+          :appstore_shipped_executable_inventory,
+          app_dir: app_dir,
+          platform: 'ios',
+          main_binary: File.join(app_dir, 'MainIOS')
+        )
+
+        assert_includes(
+          inventory[:issues].join("\n"),
+          'Recognized framework is missing Info.plist: Frameworks/Missing.framework'
+        )
+        assert(!inventory[:paths].include?(framework_binary), 'missing framework metadata must not be guessed from its directory name')
+      end
+      true
+    end
+
+    test('audits iOS app extensions and fails closed on malformed recognized bundles') do
+      Dir.mktmpdir('artifact-ios-extension-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'MainIOS', bundle_id: 'com.example.ios', platform: 'ios')
+        plugins = File.join(app_dir, 'PlugIns')
+        write_artifact_test_extension(
+          plugins,
+          name: 'ShareExtension',
+          bundle_id: 'com.example.ios.share',
+          executable_text: 'Privacy_Accessibility'
+        )
+        audit_subject = ReleaseGuardrailHarness.new
+        success_status = Struct.new(:success?).new(true)
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*command|
+          output = command.first == 'otool' ? "#{command.last}:\n" : File.read(command.last)
+          [output, success_status]
+        end
+
+        blocked = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'ios',
+          expected_bundle_id: 'com.example.ios',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        assert_eq(blocked[:verified], false)
+        assert_includes(blocked[:issues].join("\n"), 'ShareExtension.appex/ShareExtension')
+        assert_includes(blocked[:issues].join("\n"), 'Accessibility markers')
+
+        malformed = File.join(plugins, 'Malformed.xpc')
+        FileUtils.mkdir_p(malformed)
+        flat_framework = File.join(app_dir, 'Frameworks', 'Malformed.framework')
+        FileUtils.mkdir_p(flat_framework)
+        File.write(File.join(flat_framework, 'Info.plist'), '<plist><dict></dict></plist>')
+        malformed_report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'ios',
+          expected_bundle_id: 'com.example.ios',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+        assert_includes(malformed_report[:issues].join("\n"), 'missing Info.plist')
+        assert_includes(malformed_report[:issues].join("\n"), 'unreadable CFBundleExecutable')
+      end
+      true
+    end
+
+    test('unexpected artifact audit exceptions are blocking and never verified clean') do
+      Dir.mktmpdir('artifact-unexpected-error-') do |dir|
+        app_dir = write_artifact_test_app(dir, name: 'Explodes', bundle_id: 'com.example.explodes')
+        audit_subject = ReleaseGuardrailHarness.new
+        audit_subject.define_singleton_method(:appstore_artifact_capture) do |*_command|
+          raise 'tool exploded'
+        end
+
+        report = audit_subject.send(
+          :appstore_compiled_artifact_report,
+          app_dir: app_dir,
+          platform: 'macos',
+          expected_bundle_id: 'com.example.explodes',
+          review_notes_blob: '',
+          configured_product_id: '',
+          uses_storekit_unlock: false
+        )
+
+        assert_eq(report[:verified], false)
+        assert_includes(report[:issues].join("\n"), 'failed unexpectedly')
+        assert_includes(report[:issues].join("\n"), 'tool exploded')
+      end
+      true
+    end
+
     test('detects donation and support markers in App Store artifacts') do
       hits = subject.send(
         :appstore_donation_markers,
@@ -6646,6 +7030,99 @@ exit(run_tests('SaneMaster App Store Guardrail Tests') do
       )
 
       assert_eq(hits, [])
+      true
+    end
+
+    test('ignores executable permission-key decoys when built plist root keys are absent') do
+      Dir.mktmpdir('artifact-plist-decoys-') do |dir|
+        plist = File.join(dir, 'Info.plist')
+        File.write(
+          plist,
+          <<~PLIST
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0"><dict>
+              <key>CFBundleExecutable</key><string>SaneExample</string>
+            </dict></plist>
+          PLIST
+        )
+
+        plist_report = subject.send(:appstore_built_plist_permission_report, plist)
+        findings = subject.send(
+          :appstore_permission_artifact_findings,
+          review_notes_blob: 'This build does not request accessibility and uses no Apple Events.',
+          declarations: plist_report[:declarations],
+          artifact_blob: "NSAccessibilityUsageDescription\nNSAppleEventsUsageDescription",
+          strings_out: "NSAccessibilityUsageDescription\nNSAppleEventsUsageDescription",
+          nm_out: '',
+          otool_out: ''
+        )
+
+        assert_eq(plist_report[:verified], true)
+        assert_eq(plist_report[:declarations]['NSAccessibilityUsageDescription'], false)
+        assert_eq(plist_report[:declarations]['NSAppleEventsUsageDescription'], false)
+        assert_eq(findings[:issues], [])
+        assert_eq(findings[:warnings], [])
+      end
+      true
+    end
+
+    test('detects permission declarations from exact built plist root keys') do
+      Dir.mktmpdir('artifact-plist-permissions-') do |dir|
+        plist = File.join(dir, 'Info.plist')
+        File.write(
+          plist,
+          <<~PLIST
+            <?xml version="1.0" encoding="UTF-8"?>
+            <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+            <plist version="1.0"><dict>
+              <key>CFBundleExecutable</key><string>SaneExample</string>
+              <key>NSAccessibilityUsageDescription</key><string>Control selected UI.</string>
+              <key>NSAppleEventsUsageDescription</key><string>Automate the selected app.</string>
+            </dict></plist>
+          PLIST
+        )
+
+        plist_report = subject.send(:appstore_built_plist_permission_report, plist)
+        findings = subject.send(
+          :appstore_permission_artifact_findings,
+          review_notes_blob: 'This build does not request accessibility and uses no Apple Events.',
+          declarations: plist_report[:declarations],
+          artifact_blob: '',
+          strings_out: '',
+          nm_out: '',
+          otool_out: ''
+        )
+
+        assert_eq(plist_report[:verified], true)
+        assert_eq(plist_report[:declarations]['NSAccessibilityUsageDescription'], true)
+        assert_eq(plist_report[:declarations]['NSAppleEventsUsageDescription'], true)
+        assert(findings[:issues].any? { |issue| issue.include?('NSAccessibilityUsageDescription') })
+        assert(findings[:issues].any? { |issue| issue.include?('NSAppleEventsUsageDescription') })
+        assert(findings[:warnings].any? { |warning| warning.include?('Apple Events usage description') })
+      end
+      true
+    end
+
+    test('blocks artifact verification when built plist parsing fails') do
+      Dir.mktmpdir('artifact-plist-parser-failure-') do |dir|
+        plist = File.join(dir, 'Info.plist')
+        File.binwrite(plist, "not a plist\x00\xFF".b)
+
+        report = subject.send(:appstore_built_plist_permission_report, plist)
+
+        assert_eq(report[:verified], false)
+        assert(!report[:issues].empty?, 'parser failure must create a blocking artifact issue')
+        assert_includes(report[:issues].join("\n"), 'could not parse the built Info.plist')
+      end
+      true
+    end
+
+    test('blocks artifact verification when the built plist is missing') do
+      report = subject.send(:appstore_built_plist_permission_report, '/tmp/does-not-exist/Info.plist')
+
+      assert_eq(report[:verified], false)
+      assert_includes(report[:issues].join("\n"), 'could not find the built Info.plist')
       true
     end
 

--- a/scripts/validation_report.rb
+++ b/scripts/validation_report.rb
@@ -532,6 +532,7 @@ class ValidationReport
         issues_found << "[#{project}] Missing .saneprocess manifest (global hooks won't fire)"
       end
     end
+    issues_found.concat(storekit_product_parity_issues)
 
     # === GLOBAL MCP PATH CHECK ===
     # Verify legacy global .mcp.json paths are valid when present.
@@ -571,8 +572,38 @@ class ValidationReport
 
   def configured_hook_commands(hooks, hook_name)
     Array(hooks[hook_name]).flat_map do |group|
-      Array(group['hooks']).filter_map { |hook| hook['command'] }
+      Array(group['hooks']).map { |hook| hook['command'] }.compact
     end
+  end
+
+  def storekit_product_parity_issues(products_config_path: PRODUCT_CONFIG_PATH,
+                                     apps_root: File.join(SANE_APPS_ROOT, 'apps'))
+    raw = YAML.safe_load(File.read(products_config_path), permitted_classes: []) || {}
+    products = raw['products'].is_a?(Hash) ? raw['products'] : {}
+    products.each_with_object([]) do |(_slug, product), issues|
+      next unless product.is_a?(Hash)
+
+      central_id = product['storekit_product_id'].to_s.strip
+      app_name = product['name'].to_s.strip
+      next if central_id.empty? || app_name.empty?
+
+      manifest_path = File.join(apps_root, app_name, '.saneprocess')
+      next unless File.file?(manifest_path)
+
+      manifest = YAML.safe_load(File.read(manifest_path), permitted_classes: []) || {}
+      appstore = manifest['appstore'].is_a?(Hash) ? manifest['appstore'] : {}
+      iap = appstore['iap'].is_a?(Hash) ? appstore['iap'] : {}
+      {
+        'appstore.product_id' => appstore['product_id'].to_s.strip,
+        'appstore.iap.product_id' => iap['product_id'].to_s.strip
+      }.each do |label, manifest_id|
+        next if manifest_id == central_id
+
+        issues << "[#{app_name}] StoreKit product drift: config=#{central_id.inspect}, #{label}=#{manifest_id.inspect}"
+      end
+    end
+  rescue StandardError => e
+    ["StoreKit product parity check failed: #{e.class}: #{e.message}"]
   end
 
   def check_clean_session_truth(issues_found)

--- a/scripts/validation_report_test.rb
+++ b/scripts/validation_report_test.rb
@@ -2067,6 +2067,43 @@ exit(run_tests('Validation report tests') do
       true
     end
 
+    test('checks StoreKit product parity with standalone injected fixtures') do
+      Dir.mktmpdir('storekit-parity-') do |dir|
+        products_path = File.join(dir, 'products.yml')
+        apps_root = File.join(dir, 'apps')
+        manifest_path = File.join(apps_root, 'SaneScan', '.saneprocess')
+        FileUtils.mkdir_p(File.dirname(manifest_path))
+        File.write(
+          products_path,
+          "products:\n  sanescan:\n    name: SaneScan\n    storekit_product_id: com.sanescan.app.pro.yearly6\n"
+        )
+        File.write(
+          manifest_path,
+          "appstore:\n  product_id: com.sanescan.app.pro.yearly6\n  iap:\n    product_id: com.sanescan.app.pro.yearly6\n"
+        )
+        subject = ValidationReport.new
+        matching = subject.send(
+          :storekit_product_parity_issues,
+          products_config_path: products_path,
+          apps_root: apps_root
+        )
+        assert_eq(matching, [])
+
+        File.write(
+          manifest_path,
+          "appstore:\n  product_id: com.sanescan.app.pro.legacy\n  iap:\n    product_id: com.sanescan.app.pro.yearly6\n"
+        )
+        drift = subject.send(
+          :storekit_product_parity_issues,
+          products_config_path: products_path,
+          apps_root: apps_root
+        )
+        assert_includes(drift.join("\n"), 'appstore.product_id')
+        assert_includes(drift.join("\n"), 'legacy')
+      end
+      true
+    end
+
     test('classifies process and release findings separately with actions') do
       subject = ValidationReport.new
 


### PR DESCRIPTION
## Summary

- classify all retained branches against current main and selectively port only current behavior
- audit the exact staged App Store package bytes, including embedded executable payloads, and fail closed on ambiguity or mutation
- retire unverifiable existing-build reuse and require exact version/build/platform identity
- correct SaneScan StoreKit product parity and strengthen release, validation, receipt, and Safari guard coverage

## Verification

- `ruby scripts/SaneMaster.rb verify --quiet` — 1,373 tests passed
- App Store submit guardrails — 48/48
- release guardrails — 225/225
- validation — 81/81
- Safari/security guards — 117/117
- `ruby scripts/SaneMaster.rb process_eval --json` — exit 0, no blockers
- `git diff --check` — clean

## Branch audit

Stale preservation/Mini-handoff branches were not ancestry-merged because their unique changes are superseded or would restore retired behavior. Obsolete Dependabot PR #16 was closed because main already has the newer dependency. No retained remote branch was destructively deleted.