### PR TITLE
Keep Mini Terminal automation focus-neutral

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -189,6 +189,13 @@ falling back to screenshot-only inspection. Use `macos-automator` for
 deterministic AppleScript/JXA and app-specific automation tips. Use Playwright
 with the SaneApps Brave defaults for repeatable website QA.
 
+Mini Terminal-host rule: cleanup must never unminimize, raise, maximize, or
+activate an automation Terminal window. Use title-scoped reclaim during an app
+interaction sequence; reserve `--reclaim-all` for workflow boundaries. Pass
+`--restore-bundle-id <bundle-id>` when the hidden Terminal command controls an
+open app. If Terminal becomes visible or frontmost, stop the GUI sequence and
+fix the runner before clicking again.
+
 Screenshots remain final evidence, not the first control mechanism. Use
 `scripts/mini/capture-mini-screenshot.sh` only when a receipt needs an image.
 The same ladder applies in Claude when its browser/app-control plugin is

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,21 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-29 Mini Terminal focus repair
+
+- Repeated `mini-gui-run.sh --reclaim-all` calls exposed and foregrounded stale
+  automation Terminal windows, covering SaneClick during native UI control.
+- `mini-reclaim-automation-windows.sh` no longer unminimizes, raises, activates,
+  or sends focus-dependent shortcuts to Terminal. Hidden terminate-process
+  sheets are handled through their accessibility controls.
+- The runner now hides stale Terminal hosts before and after each command.
+  `AGENTS.md` and `scripts/mini/README.md` require title-scoped reclaim during
+  click sequences, `--reclaim-all` only at workflow boundaries, and
+  `--restore-bundle-id` for app control.
+- Mini proof: focused suite 30/30; live reclaim closed two stuck automation
+  windows, preserved the normal Terminal window, kept Terminal hidden, and
+  preserved Finder as the frontmost app.
+
 ## 2026-07-29 GUI action feedback loop
 
 - Owner complaint: agents treat ASC/Brave/osascript click return as success and

--- a/scripts/mini/README.md
+++ b/scripts/mini/README.md
@@ -225,6 +225,21 @@ Reclaim stale automation windows with:
 ssh mini '~/SaneApps/infra/SaneProcess/scripts/mini/mini-reclaim-automation-windows.sh --all --hide-terminal'
 ```
 
+Terminal-host automation is focus-neutral:
+
+- Reclaim must never unminimize, raise, maximize, or activate a Terminal window.
+- `mini-gui-run.sh` hides stale Terminal hosts before and after each command,
+  including when a close attempt fails.
+- If Terminal prompts to terminate child processes, reclaim uses the hidden
+  window's accessibility controls. It must not expose the prompt or use a
+  focus-dependent keyboard shortcut.
+- Use the default title-scoped reclaim during a GUI sequence. Reserve
+  `--reclaim-all` for a workflow boundary, not each click.
+- When the command controls an open app, pass `--restore-bundle-id <bundle-id>`
+  so the target app regains focus after the hidden Terminal command starts.
+- If Terminal becomes visible or frontmost, stop the GUI sequence and repair
+  the runner before retrying.
+
 ## Live Launchd Inventory
 
 ```text

--- a/scripts/mini/mini-gui-run.sh
+++ b/scripts/mini/mini-gui-run.sh
@@ -144,7 +144,9 @@ reclaim_windows() {
   fi
 }
 
-reclaim_windows
+# Cleanup is focus-neutral. Hide any stale Terminal host even when closing it
+# fails, so it cannot cover the app being automated.
+reclaim_windows --hide-terminal
 
 inner_script=$(cat <<EOF
 printf '%s\n' "\$\$" > $(shell_quote "$started_file")

--- a/scripts/mini/mini-reclaim-automation-windows.sh
+++ b/scripts/mini/mini-reclaim-automation-windows.sh
@@ -109,8 +109,49 @@ is_known_legacy_automation_window() {
 
 close_window_by_id() {
   local target_id="$1"
-  /usr/bin/osascript <<OSA
-set targetID to ${target_id}
+  local target_token="$2"
+  /usr/bin/osascript - "$target_id" "$target_token" <<'OSA'
+on pressTerminateIfPresent(targetWindow)
+  tell application "System Events"
+    tell process "Terminal"
+      try
+        if (count of sheets of targetWindow) is 0 then return false
+        set targetSheet to sheet 1 of targetWindow
+        repeat with candidateButton in buttons of targetSheet
+          try
+            if title of candidateButton is "Terminate" then
+              perform action "AXPress" of candidateButton
+              return true
+            end if
+          end try
+        end repeat
+      end try
+  end tell
+  end tell
+  return false
+end pressTerminateIfPresent
+
+on closeThroughAccessibility(targetToken)
+  tell application "System Events"
+    if not (exists process "Terminal") then return false
+    tell process "Terminal"
+      repeat with candidateWindow in windows
+        try
+          if name of candidateWindow contains targetToken then
+            if my pressTerminateIfPresent(candidateWindow) then return true
+            set closeButton to first button of candidateWindow whose description is "close button"
+            perform action "AXPress" of closeButton
+            delay 0.2
+            my pressTerminateIfPresent(candidateWindow)
+            return true
+          end if
+        end try
+      end repeat
+    end tell
+  end tell
+  return false
+end closeThroughAccessibility
+
 on windowStillExists(targetID)
   tell application "Terminal"
     repeat with candidateWindow in windows
@@ -122,6 +163,9 @@ on windowStillExists(targetID)
   return false
 end windowStillExists
 
+on run argv
+set targetID to item 1 of argv as integer
+set targetToken to item 2 of argv
 tell application "System Events"
   if not (exists process "Terminal") then return "missing-terminal"
 end tell
@@ -129,19 +173,12 @@ tell application "Terminal"
   repeat with w in windows
     try
       if id of w is equal to targetID then
-        try
-          set miniaturized of w to false
-          set index of w to 1
-        end try
         close w saving no
         repeat 20 times
           delay 0.1
           if my windowStillExists(targetID) is false then return "closed"
         end repeat
-        activate
-        try
-          tell application "System Events" to keystroke "w" using command down
-        end try
+        my closeThroughAccessibility(targetToken)
         repeat 20 times
           delay 0.1
           if my windowStillExists(targetID) is false then return "closed"
@@ -152,6 +189,7 @@ tell application "Terminal"
   end repeat
 end tell
 return "not-found"
+end run
 OSA
 }
 
@@ -221,7 +259,8 @@ while IFS=$'\t' read -r window_id window_name tab_title; do
     if [ "$dry_run" -eq 1 ]; then
       printf 'would close %s\t%s\t%s\n' "$window_id" "$window_name" "$tab_title"
     else
-      close_result="$(close_window_by_id "$window_id" 2>/dev/null || true)"
+      close_token="${tab_title:-$window_name}"
+      close_result="$(close_window_by_id "$window_id" "$close_token" 2>/dev/null || true)"
       case "$close_result" in
         closed|not-found|missing-terminal)
           ;;

--- a/scripts/mini/mini_gui_run_test.rb
+++ b/scripts/mini/mini_gui_run_test.rb
@@ -86,12 +86,32 @@ exit(run_tests('Mini GUI Runner Tests') do
 
     test('reclaim helper verifies automation windows actually close') do
       assert_includes(reclaim_source, 'on windowStillExists(targetID)')
+      assert_includes(reclaim_source, 'on closeThroughAccessibility(targetToken)')
+      assert_includes(reclaim_source, 'on pressTerminateIfPresent(targetWindow)')
+      assert_includes(reclaim_source, 'if title of candidateButton is "Terminate"')
+      assert_includes(reclaim_source, 'perform action "AXPress" of closeButton')
       assert_includes(reclaim_source, 'repeat 20 times')
       assert_includes(reclaim_source, 'if my windowStillExists(targetID) is false then return "closed"')
-      assert_includes(reclaim_source, 'tell application "System Events" to keystroke "w" using command down')
       assert_includes(reclaim_source, 'return "still-open"')
       assert_includes(reclaim_source, 'warning: automation window still open after close attempt')
       assert_includes(reclaim_source, '/usr/bin/pkill -x Terminal')
+      true
+    end
+
+    test('reclaim never exposes or foregrounds Terminal while cleaning up') do
+      assert(!reclaim_source.include?('set miniaturized of w to false'),
+             'reclaim must not expose a hidden automation window')
+      assert(!reclaim_source.include?('set index of w to 1'),
+             'reclaim must not raise an automation window above the app')
+      assert(!reclaim_source.include?("\n        activate\n"),
+             'reclaim must not foreground Terminal')
+      assert(!reclaim_source.include?('keystroke "w" using command down'),
+             'reclaim must not use a focus-stealing keyboard fallback')
+      assert(!reclaim_source.include?('set frontmost of process "Terminal"'),
+             'reclaim must not make Terminal frontmost')
+      start_reclaim = runner_source.lines.find { |line| line.strip.start_with?('reclaim_windows') && !line.include?('()') }
+      assert_eq(start_reclaim&.strip, 'reclaim_windows --hide-terminal',
+                'runner must hide stale Terminal hosts before launching work')
       true
     end
   end


### PR DESCRIPTION
## Summary
- never unminimize, raise, or activate Terminal during stale-window reclaim
- handle hidden terminate-process sheets through accessibility controls
- hide stale Terminal hosts before and after GUI commands
- document title-scoped reclaim and target-app focus rules

## Verification
- Mini GUI runner suite: 30/30 passed
- live Mini reclaim: closed two stuck automation windows, kept the normal Terminal window, kept Terminal hidden, and preserved Finder focus