### PR TITLE
Finish Mini Terminal cleanup lifecycle

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -13,14 +13,20 @@ dated research, AgentMemory, and durable architecture decisions.
   automation Terminal windows, covering SaneClick during native UI control.
 - `mini-reclaim-automation-windows.sh` no longer unminimizes, raises, activates,
   or sends focus-dependent shortcuts to Terminal. Hidden terminate-process
-  sheets are handled through their accessibility controls.
-- The runner now hides stale Terminal hosts before and after each command.
+  sheets are handled through their accessibility controls. Reclaim hides
+  Terminal before any close work, and the runner allows 15 bounded seconds for
+  process-termination sheets.
+- The runner hides stale Terminal hosts before and after each command.
+  Its window-existence check now preserves AppleScript's true/false result, and
+  the runner waits until its host is no longer accessibility-visible before
+  returning. Inert Terminal scripting ghosts with no tab, TTY, process, or AX
+  window are not treated as visible blockers.
   `AGENTS.md` and `scripts/mini/README.md` require title-scoped reclaim during
   click sequences, `--reclaim-all` only at workflow boundaries, and
   `--restore-bundle-id` for app control.
-- Mini proof: focused suite 30/30; live reclaim closed two stuck automation
-  windows, preserved the normal Terminal window, kept Terminal hidden, and
-  preserved Finder as the frontmost app.
+- Mini proof: focused suite 31/31. End-to-end runner acceptance returned status
+  `0`, preserved Finder as the frontmost app, kept Terminal hidden, and left
+  zero accessibility-visible automation windows.
 
 ## 2026-07-29 GUI action feedback loop
 

--- a/scripts/mini/README.md
+++ b/scripts/mini/README.md
@@ -228,8 +228,11 @@ ssh mini '~/SaneApps/infra/SaneProcess/scripts/mini/mini-reclaim-automation-wind
 Terminal-host automation is focus-neutral:
 
 - Reclaim must never unminimize, raise, maximize, or activate a Terminal window.
-- `mini-gui-run.sh` hides stale Terminal hosts before and after each command,
-  including when a close attempt fails.
+- Reclaim hides Terminal before it lists or closes windows, so a slow or timed
+  out close cannot expose the host. `mini-gui-run.sh` repeats the hide after
+  each command and does not return while its host remains accessibility-visible.
+  Inert Terminal scripting records with no tab, TTY, process, or accessibility
+  window are not visible blockers.
 - If Terminal prompts to terminate child processes, reclaim uses the hidden
   window's accessibility controls. It must not expose the prompt or use a
   focus-dependent keyboard shortcut.

--- a/scripts/mini/mini-gui-run.sh
+++ b/scripts/mini/mini-gui-run.sh
@@ -52,7 +52,7 @@ close_window=1
 poll_seconds=1
 start_delay_seconds="${MINI_GUI_RUN_START_DELAY:-0.6}"
 launch_grace_seconds="${MINI_GUI_RUN_LAUNCH_GRACE_SECONDS:-8}"
-cleanup_timeout_seconds="${MINI_GUI_RUN_CLEANUP_TIMEOUT_SECONDS:-5}"
+cleanup_timeout_seconds="${MINI_GUI_RUN_CLEANUP_TIMEOUT_SECONDS:-15}"
 log_file=""
 status_file=""
 title="Mini GUI Run"
@@ -176,7 +176,9 @@ window_id="$(
 
 window_still_exists() {
   local target_id="$1"
-  /usr/bin/osascript <<EOF >/dev/null 2>&1
+  local exists_state=""
+  exists_state="$(
+    /usr/bin/osascript <<EOF 2>/dev/null
 tell application "Terminal"
   repeat with w in windows
     try
@@ -186,6 +188,8 @@ tell application "Terminal"
 end tell
 return false
 EOF
+  )"
+  [ "$exists_state" = "true" ]
 }
 
 window_busy_state() {
@@ -208,20 +212,28 @@ return "missing"
 EOF
 }
 
-close_window_by_id() {
-  local target_id="$1"
-  /usr/bin/osascript <<EOF >/dev/null 2>&1
-tell application "Terminal"
-  repeat with w in windows
-    try
-      if id of w is equal to ${target_id} then
-        close w saving no
-        exit repeat
-      end if
-    end try
-  end repeat
-end tell
-EOF
+automation_window_is_accessible() {
+  local target_title="$1"
+  local accessible_state=""
+  accessible_state="$(
+    /usr/bin/osascript - "$target_title" <<'OSA' 2>/dev/null
+on run argv
+  set targetTitle to item 1 of argv
+  tell application "System Events"
+    if not (exists process "Terminal") then return false
+    tell process "Terminal"
+      repeat with candidateWindow in windows
+        try
+          if name of candidateWindow contains targetTitle then return true
+        end try
+      end repeat
+    end tell
+  end tell
+  return false
+end run
+OSA
+  )"
+  [ "$accessible_state" = "true" ]
 }
 
 idle_poll_count=0
@@ -254,11 +266,17 @@ while [ ! -f "$status_file" ]; do
   esac
 done
 
-if [ "$close_window" -eq 1 ] && [ -n "${window_id:-}" ]; then
-  run_with_timeout "$cleanup_timeout_seconds" close_window_by_id "$window_id" || true
-fi
-
 reclaim_windows --hide-terminal
+
+cleanup_poll_count=0
+while automation_window_is_accessible "$window_title" && [ "$cleanup_poll_count" -lt 50 ]; do
+  sleep 0.1
+  cleanup_poll_count=$((cleanup_poll_count + 1))
+done
+if automation_window_is_accessible "$window_title"; then
+  echo "mini-gui-run: automation window remained visible after focus-neutral cleanup: $window_id" >&2
+  exit 1
+fi
 
 if [ ! -f "$status_file" ]; then
   echo "mini-gui-run: command finished without a status file: $status_file" >&2

--- a/scripts/mini/mini-reclaim-automation-windows.sh
+++ b/scripts/mini/mini-reclaim-automation-windows.sh
@@ -54,6 +54,16 @@ if [ "$reclaim_all" -ne 1 ] && [ -z "$requested_title" ]; then
   usage
 fi
 
+hide_terminal_now() {
+  /usr/bin/osascript -e 'tell application "System Events" to set visible of process "Terminal" to false' >/dev/null 2>&1 || true
+}
+
+# Visibility is the safety boundary. Hide first so a slow or timed-out close
+# can never leave an automation Terminal window covering the target app.
+if [ "$hide_terminal" -eq 1 ] && [ "$dry_run" -ne 1 ]; then
+  hide_terminal_now
+fi
+
 list_windows() {
   /usr/bin/osascript <<'OSA'
 set outputLines to {}
@@ -197,14 +207,16 @@ window_matches_reclaim_scope() {
   local name="$1"
   local tab_title="$2"
 
-  if is_prefixed_window "$name" "$tab_title"; then
-    return 0
-  fi
   if is_requested_title_window "$name" "$tab_title"; then
     return 0
   fi
-  if [ "$reclaim_all" -eq 1 ] && is_known_legacy_automation_window "${name} ${tab_title}"; then
-    return 0
+  if [ "$reclaim_all" -eq 1 ]; then
+    if is_prefixed_window "$name" "$tab_title"; then
+      return 0
+    fi
+    if is_known_legacy_automation_window "${name} ${tab_title}"; then
+      return 0
+    fi
   fi
 
   return 1
@@ -278,7 +290,7 @@ if [ "$dry_run" -ne 1 ]; then
 fi
 
 if [ "$hide_terminal" -eq 1 ] && [ "$dry_run" -ne 1 ]; then
-  /usr/bin/osascript -e 'tell application "System Events" to set visible of process "Terminal" to false' >/dev/null 2>&1 || true
+  hide_terminal_now
 fi
 
 if [ "$dry_run" -ne 1 ]; then

--- a/scripts/mini/mini_gui_run_test.rb
+++ b/scripts/mini/mini_gui_run_test.rb
@@ -51,6 +51,8 @@ exit(run_tests('Mini GUI Runner Tests') do
 
     test('runner waits for Terminal-launched shell to start before trusting idle state') do
       assert_includes(runner_source, 'window_busy_state()')
+      assert_includes(runner_source, 'exists_state="$(')
+      assert_includes(runner_source, '[ "$exists_state" = "true" ]')
       assert_includes(runner_source, 'return "idle"')
       assert_includes(runner_source, 'launch_grace_seconds="${MINI_GUI_RUN_LAUNCH_GRACE_SECONDS:-8}"')
       assert_includes(runner_source, 'inner_script_path="$tmp_dir/command.sh"')
@@ -64,11 +66,21 @@ exit(run_tests('Mini GUI Runner Tests') do
       true
     end
 
+    test('runner does not return while its automation window still exists') do
+      assert_includes(runner_source, 'automation_window_is_accessible()')
+      assert_includes(runner_source, 'if name of candidateWindow contains targetTitle then return true')
+      assert_includes(runner_source, 'while automation_window_is_accessible "$window_title" && [ "$cleanup_poll_count" -lt 50 ]')
+      assert_includes(runner_source, 'cleanup_poll_count=$((cleanup_poll_count + 1))')
+      assert_includes(runner_source, 'mini-gui-run: automation window remained visible after focus-neutral cleanup')
+      true
+    end
+
     test('runner time-bounds post-command window cleanup') do
-      assert_includes(runner_source, 'MINI_GUI_RUN_CLEANUP_TIMEOUT_SECONDS:-5')
+      assert_includes(runner_source, 'MINI_GUI_RUN_CLEANUP_TIMEOUT_SECONDS:-15')
       assert_includes(runner_source, 'run_with_timeout()')
       assert_includes(runner_source, 'run_with_timeout "$cleanup_timeout_seconds" "$RECLAIM_SCRIPT_PATH" --all --title "$title"')
-      assert_includes(runner_source, 'run_with_timeout "$cleanup_timeout_seconds" close_window_by_id "$window_id"')
+      assert(!runner_source.include?('close_window_by_id()'),
+             'runner must leave window closing to the focus-neutral reclaim helper')
       true
     end
 
@@ -78,6 +90,8 @@ exit(run_tests('Mini GUI Runner Tests') do
       assert_includes(reclaim_source, 'if not (exists process "Terminal") then return ""')
       assert_includes(reclaim_source, '--all --hide-terminal')
       assert_includes(reclaim_source, 'is_known_legacy_automation_window')
+      assert_match(reclaim_source, /if \[ "\$reclaim_all" -eq 1 \]; then\s+if is_prefixed_window/m,
+                   'prefixed windows outside the requested title must require --all')
       assert_includes(reclaim_source, "tell application \"Terminal\" to quit saving no")
       assert_includes(reclaim_source, '" App Store "')
       assert_includes(reclaim_source, '" GUI Capture "')
@@ -109,6 +123,10 @@ exit(run_tests('Mini GUI Runner Tests') do
              'reclaim must not use a focus-stealing keyboard fallback')
       assert(!reclaim_source.include?('set frontmost of process "Terminal"'),
              'reclaim must not make Terminal frontmost')
+      hide_position = reclaim_source.index('if [ "$hide_terminal" -eq 1 ] && [ "$dry_run" -ne 1 ]; then')
+      list_position = reclaim_source.index('list_windows()')
+      assert(hide_position && list_position && hide_position < list_position,
+             'reclaim must hide Terminal before listing or closing windows')
       start_reclaim = runner_source.lines.find { |line| line.strip.start_with?('reclaim_windows') && !line.include?('()') }
       assert_eq(start_reclaim&.strip, 'reclaim_windows --hide-terminal',
                 'runner must hide stale Terminal hosts before launching work')


### PR DESCRIPTION
## Summary
- hide Terminal before cleanup so timeouts cannot expose it
- make title-scoped reclaim close only the requested runner
- remove the duplicate raw-close path that stalled on hidden modal sheets
- distinguish invisible Terminal scripting ghosts from accessibility-visible blockers
- wait for the customer-visible host window to disappear before returning

## Verification
- Mini GUI runner suite: 31/31 passed
- end-to-end Mini acceptance: runner status 0, Finder preserved, Terminal hidden, 0 accessibility-visible automation windows