### PR TITLE
Route customer UI execution evidence to Mini

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,26 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 customer UI execution-evidence routing
+
+- Branch `fix/customer-ui-execution-evidence-routing` adds
+  `customer_ui_sweep --execution-evidence PATH` to the canonical command.
+- Evidence must be a regular non-symlink JSON file under
+  `outputs/customer-ui`. Air routing validates it before sync, remaps it into
+  the exact Mini verify workspace, and verifies the synced SHA-256 before the
+  app runner receives the path.
+- Focused Mini proof passed: `release_route_test.rb` 28/28,
+  `command_registry_test.rb` 6/6, and Ruby syntax checks for the changed
+  command and contract files.
+- Full `SaneMaster.rb verify --timeout 900` remains blocked before test
+  execution by two pre-existing unregistered files:
+  `scripts/automation/app_review_watch_test.rb` and
+  `scripts/hooks/gui_feedback_test.rb`. A broader guardrail run also retained
+  two unrelated baseline failures; the new execution-evidence cases passed.
+- No installed-path screenshot acceptance was added. A deterministic positive
+  screenshot test needs a real GUI window, so it does not belong in unit tests
+  and must remain a separate Mini acceptance run.
+
 ## 2026-07-29 Mini Terminal focus repair
 
 - Repeated `mini-gui-run.sh --reclaim-all` calls exposed and foregrounded stale

--- a/scripts/SaneMaster.rb
+++ b/scripts/SaneMaster.rb
@@ -224,7 +224,7 @@ class SaneMaster
         'runtime_evidence' => { args: '[--executable PATH|--pid PID] [--break File.swift:LINE] [--expr EXPR]', desc: 'Capture LLDB runtime evidence without launching apps' },
         'visual_smoke' => { args: '[--app NAME] [--require-peekaboo] [--json] [--dry-run]', desc: 'Capture Peekaboo visual/AX evidence receipt' },
         'resource_soak' => { args: '[--adaptive|--fixed] [--duration-seconds N] [--interval-seconds N] [--json]', desc: 'Run the Mini release-candidate resource check proof' },
-        'customer_ui_sweep' => { args: '[--json] [--dry-run] [--no-exit]', desc: 'Run the app customer workflow runner, then validate the release UI contract' },
+        'customer_ui_sweep' => { args: '[--execution-evidence PATH] [--json] [--dry-run] [--no-exit]', desc: 'Run the app customer workflow runner, then validate the release UI contract' },
         'customer_ui_contract' => { args: '[--json] [--no-exit] [--strict-visual]', desc: 'Validate release-required customer UI action QA manifest and fresh receipt' },
         'menu_scan' => { args: '[--json] [--owners bundle1,bundle2]', desc: 'Menu bar diagnostics (detected/normalized/excluded)' },
         'mode' => { args: '[<AppName>] <pro|basic|free|status|owner-check|owner-install|owner-pro|owner-verify|list> [--launch] [--host local|mini]', desc: 'Set/query test mode or owner-mode install/license state' }
@@ -613,6 +613,8 @@ class SaneMaster
       return
     end
 
+    customer_ui_evidence_context = customer_ui_execution_evidence_route_context(command, args)
+
     remote_saneprocess_repo = map_local_path_to_mini(saneprocess_repo_root)
     unless remote_saneprocess_repo
       abort "❌ Could not map SaneProcess to mini: #{saneprocess_repo_root}"
@@ -644,9 +646,15 @@ class SaneMaster
       sync_local_dir_to_mini!(saneprocess_repo_root, execution_saneprocess_repo, label: 'SaneProcess')
       sync_setapp_app_workspaces_to_mini!(release_routed: release_routed) if setapp_route_command?(command)
       sync_release_artifacts_to_mini!(Dir.pwd, execution_repo) if preserve_release_artifacts
-      routed_args, routed_appstore_binding_dir = route_appstore_preflight_package_to_mini(
+      routed_args = route_customer_ui_execution_evidence_to_mini(
         command,
         args,
+        execution_repo,
+        customer_ui_evidence_context
+      )
+      routed_args, routed_appstore_binding_dir = route_appstore_preflight_package_to_mini(
+        command,
+        routed_args,
         execution_repo
       )
       if release_routed
@@ -1903,6 +1911,56 @@ PY
     [routed_args, binding_dir]
   end
 
+  def customer_ui_execution_evidence_route_context(command, args)
+    return nil unless %w[customer_ui_sweep customer-ui-sweep].include?(command.to_s)
+
+    options = parse_customer_ui_sweep_args(Array(args))
+    argument = options[:execution_evidence_path]
+    return nil if argument.to_s.empty?
+
+    local_path = customer_ui_execution_evidence_path!(argument)
+    project_root = File.realpath(Dir.pwd)
+    relative_path = local_path.delete_prefix("#{project_root}/")
+    abort '❌ Customer UI execution evidence must be inside the current project.' if relative_path == local_path
+
+    {
+      local_path: local_path,
+      relative_path: relative_path,
+      sha256: Digest::SHA256.file(local_path).hexdigest
+    }
+  rescue ArgumentError => e
+    abort "❌ #{e.message}"
+  end
+
+  def route_customer_ui_execution_evidence_to_mini(command, args, execution_repo, context)
+    routed_args = Array(args).dup
+    return routed_args unless %w[customer_ui_sweep customer-ui-sweep].include?(command.to_s)
+    return routed_args unless context
+
+    remote_path = File.join(execution_repo, context.fetch(:relative_path))
+    expected_sha256 = context.fetch(:sha256)
+    remote_ok = ssh_system(
+      'mini',
+      "test -f #{Shellwords.escape(remote_path)} && " \
+      "test ! -L #{Shellwords.escape(remote_path)} && " \
+      "test \"$(/usr/bin/shasum -a 256 #{Shellwords.escape(remote_path)} | awk '{print $1}')\" = #{Shellwords.escape(expected_sha256)}"
+    )
+    unless remote_ok
+      abort '❌ Customer UI execution evidence was not safely synced byte-for-byte into the routed Mini workspace.'
+    end
+
+    separated_index = routed_args.index('--execution-evidence')
+    if separated_index
+      routed_args[separated_index + 1] = remote_path
+    else
+      equals_index = routed_args.index { |arg| arg.start_with?('--execution-evidence=') }
+      abort '❌ Customer UI execution evidence routing lost its CLI argument.' unless equals_index
+
+      routed_args[equals_index] = "--execution-evidence=#{remote_path}"
+    end
+    routed_args
+  end
+
   def cleanup_routed_appstore_preflight_package(binding_dir)
     return if binding_dir.to_s.empty?
 
@@ -3062,15 +3120,17 @@ PY
       ]
     },
     'customer_ui_sweep' => {
-      usage: 'customer_ui_sweep [--json] [--dry-run] [--no-exit]',
+      usage: 'customer_ui_sweep [--execution-evidence PATH] [--json] [--dry-run] [--no-exit]',
       description: 'Run the project customer workflow runner on the Mini, clean the visual workspace first, and then validate the customer UI action contract.',
       flags: {
+        '--execution-evidence PATH' => 'Forward a fresh execution receipt under outputs/customer-ui to the app runner in the exact routed Mini workspace',
         '--json' => 'Print machine-readable result JSON',
         '--dry-run' => 'Validate that a project workflow runner exists without launching or clicking the app',
         '--no-exit' => 'Return the report without exiting non-zero'
       },
       examples: [
         'customer_ui_sweep --dry-run',
+        'customer_ui_sweep --execution-evidence outputs/customer-ui/run/execution-evidence.json --json',
         'customer_ui_sweep --json'
       ]
     },

--- a/scripts/sanemaster/command_registry_test.rb
+++ b/scripts/sanemaster/command_registry_test.rb
@@ -29,6 +29,15 @@ exit(run_tests('SaneMaster Command Alias Tests') do
       true
     end
 
+    test('customer UI sweep advertises routed execution evidence') do
+      summary = SaneMaster::COMMANDS.fetch(:debug).fetch(:commands).fetch('customer_ui_sweep')
+      detail = SaneMaster::COMMAND_DETAILS.fetch('customer_ui_sweep')
+      assert_includes(summary[:args], '--execution-evidence PATH')
+      assert_includes(detail[:usage], '--execution-evidence PATH')
+      assert(detail[:examples].any? { |example| example.include?('--execution-evidence') })
+      true
+    end
+
     test('App Store help requires a fresh local package and retires remote build reuse') do
       summary = SaneMaster::COMMANDS.fetch(:build).fetch(:commands).fetch('appstore_preflight')
       detail = SaneMaster::COMMAND_DETAILS.fetch('appstore_preflight')

--- a/scripts/sanemaster/customer_ui_contract.rb
+++ b/scripts/sanemaster/customer_ui_contract.rb
@@ -150,15 +150,17 @@ module SaneMasterModules
     end
 
     def customer_ui_sweep(args = [])
-      json = args.include?('--json')
-      dry_run = args.include?('--dry-run')
-      report = customer_ui_sweep_report(dry_run: dry_run)
-      if json
+      options = parse_customer_ui_sweep_args(args)
+      report = customer_ui_sweep_report(
+        dry_run: options[:dry_run],
+        execution_evidence_path: options[:execution_evidence_path]
+      )
+      if options[:json]
         puts JSON.pretty_generate(report)
       else
         puts format_customer_ui_sweep_report(report)
       end
-      exit 1 unless report[:ok] || args.include?('--no-exit')
+      exit 1 unless report[:ok] || options[:no_exit]
       report
     end
 
@@ -375,7 +377,7 @@ module SaneMasterModules
       }
     end
 
-    def customer_ui_sweep_report(dry_run: false)
+    def customer_ui_sweep_report(dry_run: false, execution_evidence_path: nil)
       config = current_saneprocess_config
       app_name = metadata_value(config, 'name') || File.basename(Dir.pwd)
       script_path = CUSTOMER_UI_SWEEP_PATHS.find { |path| File.file?(path) }
@@ -397,11 +399,14 @@ module SaneMasterModules
         }
       end
 
+      execution_evidence_path = customer_ui_execution_evidence_path!(execution_evidence_path) if execution_evidence_path
+
       if dry_run
         return {
           ok: true,
           app: app_name,
           script_path: script_path,
+          execution_evidence_path: execution_evidence_path,
           dry_run: true,
           issues: []
         }
@@ -435,7 +440,9 @@ module SaneMasterModules
           next({ ok: false, app: app_name, script_path: script_path, issues: visual_precheck[:issues] })
         end
 
-        output, status = customer_ui_run_command(RbConfig.ruby, script_path)
+        runner_command = [RbConfig.ruby, script_path]
+        runner_command.concat(['--execution-evidence', execution_evidence_path]) if execution_evidence_path
+        output, status = customer_ui_run_command(*runner_command)
         unless status.success?
           next({ ok: false, app: app_name, script_path: script_path, issues: ["Customer UI workflow runner failed: #{output}"] })
         end
@@ -445,6 +452,7 @@ module SaneMasterModules
           ok: contract[:ok],
           app: app_name,
           script_path: script_path,
+          execution_evidence_path: execution_evidence_path,
           contract: contract,
           runner_output: output,
           issues: Array(contract[:issues])
@@ -569,6 +577,63 @@ module SaneMasterModules
     end
 
     private
+
+    def parse_customer_ui_sweep_args(args)
+      options = {
+        json: false,
+        dry_run: false,
+        no_exit: false,
+        execution_evidence_path: nil
+      }
+      i = 0
+      while i < args.length
+        arg = args[i]
+        case arg
+        when '--json'
+          options[:json] = true
+        when '--dry-run'
+          options[:dry_run] = true
+        when '--no-exit'
+          options[:no_exit] = true
+        when '--local'
+          # Consumed by SaneMaster Mini routing.
+        when '--execution-evidence'
+          raise ArgumentError, '--execution-evidence may only be supplied once' if options[:execution_evidence_path]
+
+          options[:execution_evidence_path] = customer_ui_required_arg(args, i, arg)
+          i += 1
+        when /\A--execution-evidence=(.+)\z/
+          raise ArgumentError, '--execution-evidence may only be supplied once' if options[:execution_evidence_path]
+
+          options[:execution_evidence_path] = Regexp.last_match(1)
+        else
+          raise ArgumentError, "unknown option: #{arg}"
+        end
+        i += 1
+      end
+      options
+    end
+
+    def customer_ui_execution_evidence_path!(path)
+      project_root = File.expand_path(Dir.pwd)
+      allowed_root = File.join(project_root, 'outputs', 'customer-ui')
+      expanded = File.expand_path(path.to_s, project_root)
+      raise ArgumentError, '--execution-evidence must be a JSON file' unless File.extname(expanded).downcase == '.json'
+
+      safe_customer_ui_directory_path!(File.dirname(expanded))
+      stat = File.lstat(expanded)
+      raise ArgumentError, '--execution-evidence must be a regular non-symlink file' unless stat.file? && !stat.symlink?
+
+      real_path = File.realpath(expanded)
+      real_allowed_root = File.realpath(allowed_root)
+      unless real_path.start_with?("#{real_allowed_root}/")
+        raise ArgumentError, '--execution-evidence must be under outputs/customer-ui'
+      end
+
+      real_path
+    rescue Errno::ENOENT
+      raise ArgumentError, "customer UI execution evidence not found: #{expanded}"
+    end
 
     def customer_ui_report_utf8(value)
       value.to_s.encode('UTF-8', invalid: :replace, undef: :replace, replace: '�')

--- a/scripts/sanemaster/release_route_test.rb
+++ b/scripts/sanemaster/release_route_test.rb
@@ -176,6 +176,152 @@ exit(run_tests('SaneMaster Release Routing Tests') do
       end
       true
     end
+
+    test('remaps customer UI execution evidence into the exact routed Mini workspace') do
+      with_temp_repo do |repo|
+        evidence_dir = File.join(repo, 'outputs', 'customer-ui', 'run-123')
+        evidence = File.join(evidence_dir, 'execution-evidence.json')
+        execution_repo = '/Users/stephansmac/.sanemaster/verify-workspaces/abcd/SaneApps/apps/SaneClick'
+        FileUtils.mkdir_p(evidence_dir)
+        File.write(evidence, "{\"status\":\"passed\"}\n")
+
+        subject.system_calls.clear
+        Dir.chdir(repo) do
+          args = ['--execution-evidence', evidence, '--json']
+          context = subject.send(:customer_ui_execution_evidence_route_context, 'customer_ui_sweep', args)
+          routed_args = subject.send(
+            :route_customer_ui_execution_evidence_to_mini,
+            'customer_ui_sweep',
+            args,
+            execution_repo,
+            context
+          )
+
+          expected_remote = File.join(execution_repo, 'outputs', 'customer-ui', 'run-123', 'execution-evidence.json')
+          assert_eq(routed_args, ['--execution-evidence', expected_remote, '--json'])
+          safety_check = subject.system_calls.find do |call|
+            call.first == 'ssh' &&
+              call.any? do |part|
+                part.to_s.include?("test -f #{expected_remote}") &&
+                  part.to_s.include?('/usr/bin/shasum -a 256') &&
+                  part.to_s.include?(Digest::SHA256.file(evidence).hexdigest)
+              end
+          end
+          assert(safety_check, 'expected a regular non-symlink digest check for the synced Mini evidence')
+        end
+      end
+      true
+    end
+
+    test('remaps equals-form customer UI execution evidence without changing other arguments') do
+      with_temp_repo do |repo|
+        evidence_dir = File.join(repo, 'outputs', 'customer-ui')
+        evidence = File.join(evidence_dir, 'execution-evidence.json')
+        execution_repo = '/Users/stephansmac/.sanemaster/verify-workspaces/abcd/SaneApps/apps/SaneClick'
+        FileUtils.mkdir_p(evidence_dir)
+        File.write(evidence, "{\"status\":\"passed\"}\n")
+
+        subject.system_calls.clear
+        Dir.chdir(repo) do
+          args = ["--execution-evidence=#{evidence}", '--no-exit']
+          context = subject.send(:customer_ui_execution_evidence_route_context, 'customer-ui-sweep', args)
+          routed_args = subject.send(
+            :route_customer_ui_execution_evidence_to_mini,
+            'customer-ui-sweep',
+            args,
+            execution_repo,
+            context
+          )
+
+          expected_remote = File.join(execution_repo, 'outputs', 'customer-ui', 'execution-evidence.json')
+          assert_eq(routed_args, ["--execution-evidence=#{expected_remote}", '--no-exit'])
+        end
+      end
+      true
+    end
+
+    test('forwards safe customer UI execution evidence to the app runner') do
+      with_temp_repo do |repo|
+        FileUtils.mkdir_p(File.join(repo, 'scripts'))
+        FileUtils.mkdir_p(File.join(repo, 'outputs', 'customer-ui'))
+        evidence_path = File.join(repo, 'outputs', 'customer-ui', 'execution-evidence.json')
+        File.write(File.join(repo, '.saneprocess'), "name: SaneExample\n")
+        File.write(File.join(repo, 'scripts', 'customer_ui_action_sweep.rb'), "#!/usr/bin/env ruby\n")
+        File.write(evidence_path, "{\"status\":\"passed\"}\n")
+
+        calls = []
+        subject.define_singleton_method(:customer_ui_mini_host?) { true }
+        subject.define_singleton_method(:customer_ui_prepare_target_before_sweep) { |_app| [] }
+        subject.define_singleton_method(:customer_ui_cleanup_before_sweep) { |_app| [] }
+        subject.define_singleton_method(:customer_ui_refresh_runtime_evidence_before_sweep) { |_app| [] }
+        subject.define_singleton_method(:customer_ui_visual_precheck) { |_app| { ok: true, issues: [] } }
+        subject.define_singleton_method(:customer_ui_contract_report) do |config: nil, strict_visual: false|
+          { ok: true, issues: [], config: config, strict_visual: strict_visual }
+        end
+        subject.define_singleton_method(:customer_ui_run_command) do |*cmd|
+          calls << cmd
+          [cmd.join(' '), Struct.new(:success?).new(true)]
+        end
+
+        report = nil
+        Dir.chdir(repo) do
+          report = subject.customer_ui_sweep_report(
+            dry_run: false,
+            execution_evidence_path: 'outputs/customer-ui/execution-evidence.json'
+          )
+        end
+
+        assert(report[:ok], "expected execution-evidence sweep to pass: #{report.inspect}")
+        assert_eq(report[:execution_evidence_path], File.realpath(evidence_path))
+        assert_eq(
+          calls.last,
+          [
+            RbConfig.ruby,
+            'scripts/customer_ui_action_sweep.rb',
+            '--execution-evidence',
+            File.realpath(evidence_path)
+          ]
+        )
+      end
+      true
+    ensure
+      subject.singleton_class.remove_method(:customer_ui_mini_host?) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_prepare_target_before_sweep) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_cleanup_before_sweep) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_refresh_runtime_evidence_before_sweep) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_visual_precheck) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_contract_report) rescue nil
+      subject.singleton_class.remove_method(:customer_ui_run_command) rescue nil
+    end
+
+    test('rejects customer UI execution evidence outside its durable root and symlinks') do
+      with_temp_repo do |repo|
+        FileUtils.mkdir_p(File.join(repo, 'outputs', 'customer-ui'))
+        outside = File.join(repo, 'outside.json')
+        symlink = File.join(repo, 'outputs', 'customer-ui', 'linked.json')
+        File.write(outside, "{}\n")
+        File.symlink(outside, symlink)
+
+        outside_error = nil
+        symlink_error = nil
+        Dir.chdir(repo) do
+          begin
+            subject.send(:customer_ui_execution_evidence_path!, outside)
+          rescue ArgumentError => e
+            outside_error = e.message
+          end
+          begin
+            subject.send(:customer_ui_execution_evidence_path!, symlink)
+          rescue ArgumentError => e
+            symlink_error = e.message
+          end
+        end
+
+        assert_includes(outside_error, 'must be under outputs/customer-ui')
+        assert_includes(symlink_error, 'regular non-symlink file')
+      end
+      true
+    end
   end
 
   test_category('Workspace sync to mini') do


### PR DESCRIPTION
## Summary

- add `customer_ui_sweep --execution-evidence PATH` and forward it to the app runner
- restrict evidence to regular non-symlink JSON under `outputs/customer-ui`
- remap evidence into the exact Mini workspace and verify its SHA-256 after sync

## Test plan

- Mini: `ruby scripts/sanemaster/release_route_test.rb` (28/28 passed)
- Mini: `ruby scripts/sanemaster/command_registry_test.rb` (6/6 passed)
- Mini: Ruby syntax checks passed for `SaneMaster.rb` and `customer_ui_contract.rb`
- `git diff --check` passed

Full `SaneMaster.rb verify --timeout 900` remains blocked before test execution by two pre-existing unregistered test files. The broad release guardrail suite also retains two unrelated baseline failures. No screenshot acceptance was added because a deterministic positive case requires a real GUI window and does not belong in unit tests.