### PR TITLE
Keep Mini Terminal hidden during GUI runs

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,22 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 Mini GUI host visibility repair
+
+- A fresh SaneClick 1.3.3 app-only capture proved the screenshot bytes were
+  clean, but the logged-in GUI runner exposed a large Terminal window titled
+  `SaneApps Automation: Mini Screenshot` while the command ran. The target app
+  stayed non-frontmost until post-command reclaim finished.
+- `mini-gui-run.applescript` now binds window mutations to the exact Terminal
+  window launched for the command, miniaturizes that window, and forces the
+  Terminal host process hidden before the launcher returns. This keeps the
+  automation host from covering the target even if Terminal reverses
+  miniaturization while a busy tab changes state.
+- Focused Mini proof passed 32/32 and the AppleScript compiled. A live
+  12-second Mini acceptance command finished successfully while the bound AX
+  read reported no Terminal process or window. SaneClick's live proof remains
+  separate and resumes only after this shared fix lands.
+
 ## 2026-07-30 customer UI execution-evidence routing
 
 - Branch `fix/customer-ui-execution-evidence-routing` adds

--- a/scripts/mini/mini-gui-run.applescript
+++ b/scripts/mini/mini-gui-run.applescript
@@ -52,17 +52,29 @@ on run argv
     delay 0.5
     set targetTab to do script shellCommand
     delay 0.2
-    set targetWindowID to id of front window
     try
       set custom title of targetTab to windowTitle
     end try
+    set targetWindow to first window whose selected tab is targetTab
+    set targetWindowID to id of targetWindow
     try
-      set bounds of front window to {-2200, 80, -1200, 720}
+      set bounds of targetWindow to {-2200, 80, -1200, 720}
     end try
     try
-      set miniaturized of front window to true
+      set miniaturized of targetWindow to true
     end try
   end tell
+
+  -- Terminal can ignore or briefly reverse miniaturization while the launched
+  -- command changes tab state. Hiding the host process before this launcher
+  -- returns prevents the automation window from covering the target app.
+  try
+    tell application "System Events"
+      if exists process "Terminal" then
+        set visible of process "Terminal" to false
+      end if
+    end tell
+  end try
 
   try
     if explicitRestoreBundleID is not "" then

--- a/scripts/mini/mini_gui_run_test.rb
+++ b/scripts/mini/mini_gui_run_test.rb
@@ -49,6 +49,20 @@ exit(run_tests('Mini GUI Runner Tests') do
       true
     end
 
+    test('launcher hides its exact Terminal host before returning control') do
+      assert_includes(apple_script_source, 'set targetWindow to first window whose selected tab is targetTab')
+      assert_includes(apple_script_source, 'set targetWindowID to id of targetWindow')
+      assert_includes(apple_script_source, 'set bounds of targetWindow to {-2200, 80, -1200, 720}')
+      assert_includes(apple_script_source, 'set miniaturized of targetWindow to true')
+      assert_includes(apple_script_source, 'set visible of process "Terminal" to false')
+
+      hide_position = apple_script_source.index('set visible of process "Terminal" to false')
+      return_position = apple_script_source.index('return (targetWindowID as string)')
+      assert(hide_position && return_position && hide_position < return_position,
+             'launcher must hide Terminal before returning the automation window id')
+      true
+    end
+
     test('runner waits for Terminal-launched shell to start before trusting idle state') do
       assert_includes(runner_source, 'window_busy_state()')
       assert_includes(runner_source, 'exists_state="$(')


### PR DESCRIPTION
## Summary
- bind Mini GUI mutations to the exact Terminal window launched for the command
- hide the Terminal host before the launcher returns so it cannot cover the target app
- add a focused regression test and record the live acceptance proof

## Test plan
- Mini: `ruby scripts/mini/mini_gui_run_test.rb` (32/32 passed)
- Mini: `osacompile` accepted `mini-gui-run.applescript`
- Mini live acceptance: 12-second GUI-run command completed while AX reported no Terminal process/window
- canonical SaneProcess verify reached the existing registry gate; it remains blocked by unregistered `app_review_watch_test.rb` and `gui_feedback_test.rb` before suite execution