### PR TITLE
Fix Mini screenshot help fast path

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,16 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 Mini screenshot help fast path
+
+- `capture-mini-screenshot.sh -h` and `--help` now print local usage and exit
+  successfully before timeout validation, helper checks, host resolution,
+  SSH, rsync, the visual guard, or the Mini GUI runner.
+- The focused behavioral regression stubs SSH and rsync, supplies invalid
+  runtime configuration, runs both help flags, and requires zero side effects.
+  `mini_gui_run_test.rb` passes 33/33 locally; Mini proof is required before
+  merge.
+
 ## 2026-07-30 Mini GUI host visibility repair
 
 - A fresh SaneClick 1.3.3 app-only capture proved the screenshot bytes were

--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -14,8 +14,8 @@ dated research, AgentMemory, and durable architecture decisions.
   SSH, rsync, the visual guard, or the Mini GUI runner.
 - The focused behavioral regression stubs SSH and rsync, supplies invalid
   runtime configuration, runs both help flags, and requires zero side effects.
-  `mini_gui_run_test.rb` passes 33/33 locally; Mini proof is required before
-  merge.
+  `mini_gui_run_test.rb` passes 33/33 on the Mini. A direct Mini `--help` run
+  with invalid runtime configuration exited 0 in 0.00 seconds.
 
 ## 2026-07-30 Mini GUI host visibility repair
 

--- a/scripts/mini/capture-mini-screenshot.sh
+++ b/scripts/mini/capture-mini-screenshot.sh
@@ -12,20 +12,10 @@ MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS="${MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECON
 SKIP_CLEANUP=false
 use_local_runner=false
 
-case "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" in
-  ''|*[!0-9]*)
-    echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
-    exit 2
-    ;;
-esac
-if [ "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" -le 0 ]; then
-  echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
-  exit 2
-fi
-
-usage() {
-  cat <<'EOF' >&2
+print_usage() {
+  cat <<'EOF'
 Usage:
+  capture-mini-screenshot.sh -h|--help
   capture-mini-screenshot.sh desktop [--copy-to LOCAL_DIR] [take_screenshot.py args...]
   capture-mini-screenshot.sh [--skip-cleanup] [take_screenshot.py args...]
   capture-mini-screenshot.sh [take_screenshot.py args...]
@@ -56,10 +46,34 @@ Notes:
     the default cleanup would hide the very window you need to see. Then Read the
     PNG; a capture you don't open proves nothing.
 EOF
+}
+
+usage() {
+  print_usage >&2
   exit 2
 }
 
 [ $# -gt 0 ] || usage
+
+for arg in "$@"; do
+  case "$arg" in
+    -h|--help)
+      print_usage
+      exit 0
+      ;;
+  esac
+done
+
+case "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" in
+  ''|*[!0-9]*)
+    echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
+    exit 2
+    ;;
+esac
+if [ "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" -le 0 ]; then
+  echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
+  exit 2
+fi
 
 local_copy_to=""
 capture_video=false

--- a/scripts/mini/mini_gui_run_test.rb
+++ b/scripts/mini/mini_gui_run_test.rb
@@ -2,6 +2,8 @@
 # frozen_string_literal: true
 
 require_relative '../hooks/test/test_framework'
+require 'open3'
+require 'tmpdir'
 
 include TestFramework
 
@@ -149,6 +151,45 @@ exit(run_tests('Mini GUI Runner Tests') do
   end
 
   test_category('Screenshot wrapper safety') do
+    test('capture wrapper prints local help without Mini or GUI side effects') do
+      Dir.mktmpdir('capture-mini-help-test') do |stub_dir|
+        marker_path = File.join(stub_dir, 'side-effects.log')
+        %w[ssh rsync].each do |command|
+          stub_path = File.join(stub_dir, command)
+          File.write(
+            stub_path,
+            <<~SH
+              #!/bin/sh
+              printf '%s\n' "$0 $*" >> "$SANE_HELP_SIDE_EFFECT_MARKER"
+              exit 97
+            SH
+          )
+          File.chmod(0o755, stub_path)
+        end
+
+        %w[-h --help].each do |help_flag|
+          File.delete(marker_path) if File.exist?(marker_path)
+          stdout, stderr, status = Open3.capture3(
+            {
+              'PATH' => "#{stub_dir}:#{ENV.fetch('PATH')}",
+              'LOCAL_SCREENSHOT_HELPER_DIR' => File.join(stub_dir, 'missing-helper'),
+              'MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS' => 'invalid',
+              'SANE_HELP_SIDE_EFFECT_MARKER' => marker_path
+            },
+            '/bin/bash',
+            SCREENSHOT_WRAPPER_PATH,
+            help_flag
+          )
+
+          assert(status.success?, "#{help_flag} must exit successfully, got #{status.exitstatus}")
+          assert_includes(stdout, 'Usage:')
+          assert_eq(stderr, '', "#{help_flag} must not report an error")
+          assert(!File.exist?(marker_path), "#{help_flag} must not call ssh or rsync")
+        end
+      end
+      true
+    end
+
     test('capture wrapper resolves the Mini host before rsync and ssh') do
       assert_includes(screenshot_wrapper_source, 'resolve_mini_host()')
       assert_includes(screenshot_wrapper_source, 'MINI_HOST_FALLBACKS')


### PR DESCRIPTION
## Summary
- handle `-h` and `--help` locally before runtime validation or Mini host setup
- keep help out of SSH, rsync, visual guard, and Terminal GUI paths
- add a behavioral regression for both flags with hostile config and side-effect stubs

## Test plan
- `bash -n scripts/mini/capture-mini-screenshot.sh`
- `ruby scripts/mini/mini_gui_run_test.rb` (33/33 on Mac Mini)
- direct Mini `--help` with invalid runtime config: exit 0 in 0.00s
