### PR TITLE
Fix Release test-mode provisioning parity

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,29 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 Release test-mode provisioning parity
+
+- SaneHosts `test_mode --release` failed twice because the runtime build path
+  asked Xcode for the named Developer ID profile without the provisioning
+  update/authentication arguments used by the successful release archive.
+  The cached profile is valid and byte-identical to the profile embedded in
+  `/Applications/SaneHosts.app`; profile regeneration is not the fix.
+- Release test mode now uses `generic/platform=macOS`,
+  `-allowProvisioningUpdates`, and the complete ASC authentication argument
+  set when all three credential values are available. Debug behavior is
+  unchanged: it keeps `platform=macOS` and receives no provisioning flags.
+  Authentication values are redacted from captured or timeout output.
+- Focused proof passed locally and on the Mini: `test_mode_test.rb` 27/27.
+  Canonical Mini `SaneMaster.rb verify --timeout 900` stopped before tests on
+  the two existing unregistered test files already recorded below:
+  `scripts/automation/app_review_watch_test.rb` and
+  `scripts/hooks/gui_feedback_test.rb`. Workflow receipt
+  `f1aed7d97091d7b167c371abecb8d796`; cleanup receipt
+  `98ab18300869304b5d02f5172b598a45`.
+- No app was launched. The next live SaneHosts retry belongs to the parent
+  workflow after review and merge. The Mini Terminal visibility fixes below
+  remain unchanged.
+
 ## 2026-07-30 Mini screenshot help fast path
 
 - `capture-mini-screenshot.sh -h` and `--help` now print local usage and exit

--- a/scripts/sanemaster/test_mode.rb
+++ b/scripts/sanemaster/test_mode.rb
@@ -849,8 +849,10 @@ module SaneMasterModules
       ENV['SANEMASTER_BUILD_CONFIG'] = build_config
 
       cmd = ['xcodebuild', *xcodebuild_container_args, '-scheme', project_scheme, '-configuration', build_config,
-             '-destination', 'platform=macOS', 'ENABLE_DEBUG_DYLIB=NO', *release_runtime_build_args(build_config), 'build']
+             '-destination', test_mode_build_destination(build_config), *release_runtime_provisioning_args(build_config),
+             'ENABLE_DEBUG_DYLIB=NO', *release_runtime_build_args(build_config), 'build']
       stdout, status = capture2e_without_reader_thread(*cmd, label: 'test_mode build', timeout: test_mode_build_timeout_seconds)
+      stdout = redact_test_mode_signing_auth(stdout)
 
       if should_retry_unsigned_debug?(build_config: build_config, output: stdout, status: status)
         fallback_config = build_config == 'Release-AppStore' ? build_config : 'Debug'
@@ -906,7 +908,7 @@ module SaneMasterModules
 
           next unless timeout && (Time.now - started_at) >= timeout
 
-          output << "\n#{label} timeout after #{timeout}s: #{cmd.join(' ')}\n"
+          output << "\n#{label} timeout after #{timeout}s: #{redact_test_mode_signing_auth(cmd.join(' '))}\n"
           terminate_process_group(wait_thr)
           status = command_failed_status
           drain_command_output(stdout_err, output, max_drain_seconds: 1.0)
@@ -975,6 +977,41 @@ module SaneMasterModules
       configured = saneprocess_value('release', 'test_mode_extra_args') ||
                    saneprocess_value('release', 'archive_extra_args')
       Array(configured).map(&:to_s).map(&:strip).reject(&:empty?)
+    end
+
+    def test_mode_build_destination(build_config)
+      build_config == 'Release' ? 'generic/platform=macOS' : 'platform=macOS'
+    end
+
+    def release_runtime_provisioning_args(build_config)
+      return [] unless build_config == 'Release'
+
+      args = ['-allowProvisioningUpdates']
+      key_path = ENV['ASC_AUTH_KEY_PATH'].to_s.strip
+      key_id = ENV['ASC_AUTH_KEY_ID'].to_s.strip
+      issuer_id = ENV['ASC_AUTH_ISSUER_ID'].to_s.strip
+      return args if key_path.empty? || key_id.empty? || issuer_id.empty?
+      key_path = File.expand_path(key_path)
+      return args unless File.file?(key_path)
+
+      args + [
+        '-authenticationKeyPath', key_path,
+        '-authenticationKeyID', key_id,
+        '-authenticationKeyIssuerID', issuer_id
+      ]
+    end
+
+    def redact_test_mode_signing_auth(output)
+      redacted = output.to_s.dup
+      %w[ASC_AUTH_KEY_PATH ASC_AUTH_KEY_ID ASC_AUTH_ISSUER_ID].each do |key|
+        value = ENV[key].to_s
+        redacted.gsub!(value, '[REDACTED]') unless value.empty?
+      end
+      redacted.gsub!(
+        /(-authenticationKey(?:Path|ID|IssuerID)\s+)(?:"[^"]*"|'[^']*'|\S+)/,
+        '\1[REDACTED]'
+      )
+      redacted
     end
 
     def prepare_signing_session_for_build(build_config)

--- a/scripts/sanemaster/test_mode_test.rb
+++ b/scripts/sanemaster/test_mode_test.rb
@@ -325,6 +325,43 @@ exit(run_tests('SaneMaster Test Mode Fallback Tests') do
       true
     end
 
+    test('release test_mode uses generic destination and authenticated provisioning updates') do
+      saved = %w[ASC_AUTH_KEY_PATH ASC_AUTH_KEY_ID ASC_AUTH_ISSUER_ID].to_h { |key| [key, ENV[key]] }
+
+      Dir.mktmpdir('sanemaster-test-mode-auth') do |dir|
+        key_path = File.join(dir, 'AuthKey_TEST.p8')
+        File.write(key_path, 'test fixture')
+        ENV['ASC_AUTH_KEY_PATH'] = key_path
+        ENV['ASC_AUTH_KEY_ID'] = 'TEST_KEY_ID'
+        ENV['ASC_AUTH_ISSUER_ID'] = 'TEST_ISSUER_ID'
+
+        args = subject.send(:release_runtime_provisioning_args, 'Release')
+
+        assert_eq(subject.send(:test_mode_build_destination, 'Release'), 'generic/platform=macOS')
+        assert_eq(
+          args,
+          [
+            '-allowProvisioningUpdates',
+            '-authenticationKeyPath', key_path,
+            '-authenticationKeyID', 'TEST_KEY_ID',
+            '-authenticationKeyIssuerID', 'TEST_ISSUER_ID'
+          ]
+        )
+
+        rendered = subject.send(:redact_test_mode_signing_auth, args.join(' '))
+        assert(!rendered.include?(key_path), 'output must redact the authentication key path')
+        assert(!rendered.include?('TEST_KEY_ID'), 'output must redact the authentication key id')
+        assert(!rendered.include?('TEST_ISSUER_ID'), 'output must redact the authentication issuer id')
+        assert_includes(rendered, '-authenticationKeyPath [REDACTED]')
+      end
+
+      true
+    ensure
+      saved&.each do |key, value|
+        value.nil? ? ENV.delete(key) : ENV[key] = value
+      end
+    end
+
     test('debug test_mode build does not inherit release signing args') do
       Dir.mktmpdir('sanemaster-test-mode-debug-signing') do |dir|
         File.write(
@@ -340,6 +377,8 @@ exit(run_tests('SaneMaster Test Mode Fallback Tests') do
           harness = TestModeHarness.new
 
           assert(harness.send(:release_runtime_build_args, 'Debug').empty?)
+          assert(harness.send(:release_runtime_provisioning_args, 'Debug').empty?)
+          assert_eq(harness.send(:test_mode_build_destination, 'Debug'), 'platform=macOS')
         end
       end
 


### PR DESCRIPTION
## Summary

- use the proven release destination and provisioning-update path for Release `test_mode`
- pass ASC authentication only when the complete credential set and key file are present
- redact authentication values from captured build and timeout output
- preserve Debug destination and signing behavior unchanged

## Verification

- Local focused test: `test_mode_test.rb` 27/27 passed
- Mini focused test: `test_mode_test.rb` 27/27 passed
- Canonical Mini `SaneMaster.rb verify --timeout 900` stopped before tests on the two pre-existing unregistered files already documented in `SESSION_HANDOFF.md`:
  - `scripts/automation/app_review_watch_test.rb`
  - `scripts/hooks/gui_feedback_test.rb`
- Verify workflow receipt: `f1aed7d97091d7b167c371abecb8d796`
- Cleanup receipt: `98ab18300869304b5d02f5172b598a45`

No app was built or launched outside the canonical headless verification route. No live SaneHosts retry was run.