### PR TITLE
Fix isolated test-mode DerivedData discovery

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,18 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 Isolated runtime DerivedData discovery
+
+- The first SaneHosts live retry after provisioning parity built successfully,
+  but `CFFIXED_USER_HOME` caused Xcode to place DerivedData under the isolated
+  fixture home. `test_mode` searched only the login user's DerivedData, treated
+  the official install as stale, rebuilt, then failed to find the new app.
+- `test_mode` now searches both the login user's DerivedData and the active
+  `CFFIXED_USER_HOME` DerivedData root. The regression test creates a runnable
+  app bundle under an isolated fixture home and proves it is selected.
+- The retry failed before launch. No SaneHosts customer action ran and no
+  production hosts file was changed.
+
 ## 2026-07-30 Release test-mode provisioning parity
 
 - SaneHosts `test_mode --release` failed twice because the runtime build path

--- a/scripts/sanemaster/test_mode.rb
+++ b/scripts/sanemaster/test_mode.rb
@@ -1153,8 +1153,17 @@ module SaneMasterModules
     end
 
     def built_app_candidates(build_config)
-      dd_glob = File.expand_path("~/Library/Developer/Xcode/DerivedData/#{project_name}-*/Build/Products/#{build_config}")
-      Dir.glob(File.join(dd_glob, "#{project_name}.app")).sort_by { |path| File.mtime(path) }.reverse
+      derived_data_roots.flat_map do |root|
+        dd_glob = File.join(root, "#{project_name}-*", 'Build', 'Products', build_config)
+        Dir.glob(File.join(dd_glob, "#{project_name}.app"))
+      end.uniq.sort_by { |path| File.mtime(path) }.reverse
+    end
+
+    def derived_data_roots
+      roots = [File.expand_path('~/Library/Developer/Xcode/DerivedData')]
+      fixed_home = ENV['CFFIXED_USER_HOME'].to_s.strip
+      roots << File.join(File.expand_path(fixed_home), 'Library', 'Developer', 'Xcode', 'DerivedData') unless fixed_home.empty?
+      roots.uniq
     end
 
     def app_bundle_executable_path(app_path)

--- a/scripts/sanemaster/test_mode_test.rb
+++ b/scripts/sanemaster/test_mode_test.rb
@@ -141,6 +141,36 @@ exit(run_tests('SaneMaster Test Mode Fallback Tests') do
       true
     end
 
+    test('launch finds build products under an isolated CFFIXED_USER_HOME') do
+      saved_fixed_home = ENV['CFFIXED_USER_HOME']
+
+      Dir.mktmpdir('sanemaster-isolated-home') do |dir|
+        project_dir = File.join(dir, 'project')
+        fixed_home = File.join(dir, 'fixture-home')
+        app_path = File.join(
+          fixed_home,
+          'Library/Developer/Xcode/DerivedData/SaneHosts-test/Build/Products/Release/SaneHosts.app'
+        )
+        executable = File.join(app_path, 'Contents/MacOS/SaneHosts')
+        FileUtils.mkdir_p([project_dir, File.dirname(executable)])
+        File.write(File.join(project_dir, '.saneprocess'), "name: SaneHosts\nscheme: SaneHosts\n")
+        File.write(executable, "#!/bin/sh\n")
+        FileUtils.chmod(0o755, executable)
+        ENV['CFFIXED_USER_HOME'] = fixed_home
+
+        Dir.chdir(project_dir) do
+          harness = TestModeHarness.new
+
+          assert_includes(harness.send(:built_app_candidates, 'Release'), app_path)
+          assert(harness.send(:app_bundle_executable?, app_path), 'isolated app must have a runnable executable')
+        end
+      end
+
+      true
+    ensure
+      saved_fixed_home.nil? ? ENV.delete('CFFIXED_USER_HOME') : ENV['CFFIXED_USER_HOME'] = saved_fixed_home
+    end
+
     test('no-keychain launch state is passed through LaunchServices open') do
       result = subject.send(
         :open_launch_env_pairs,


### PR DESCRIPTION
## Summary
- find Release products under CFFIXED_USER_HOME fixture DerivedData
- keep normal login-user DerivedData discovery
- add a runnable isolated-home regression test

## Verification
- ruby scripts/sanemaster/test_mode_test.rb (28/28)
- git diff --check