### PR TITLE
Harden shared launcher staging paths

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -7,6 +7,19 @@ Repo: `~/SaneApps/infra/SaneProcess`
 This file is current state only. Historical detail belongs in git history,
 dated research, AgentMemory, and durable architecture decisions.
 
+## 2026-07-30 Launcher path and secret hardening
+
+- End-session security review found that canonical app path overrides were not
+  constrained before the staging replacement path, signature checks used
+  shell-interpolated paths, and Release test mode imported unrelated secrets
+  into the build environment.
+- Both shared launchers now allow only the exact system, user Applications, or
+  SaneApps transient path for the named app. Existing app replacement moves
+  the old bundle to Trash. Signature and bundle-ID reads use argument arrays,
+  and the secrets loader imports only signing and keychain variables.
+- Regression coverage rejects an arbitrary directory override and proves that
+  an unrelated commerce key is not imported into the build environment.
+
 ## 2026-07-30 Isolated runtime DerivedData discovery
 
 - The first SaneHosts live retry after provisioning parity built successfully,

--- a/scripts/app_test_mode_test.rb
+++ b/scripts/app_test_mode_test.rb
@@ -43,6 +43,16 @@ exit(run_tests('App Test Mode Bootstrap Tests') do
       assert_includes(source, '/tmp/saneapps-staging.noindex/${app}.app')
       true
     end
+
+    test('sane_test validates canonical app overrides and avoids shell interpolation') do
+      source = File.read(SANE_TEST_PATH)
+
+      assert_includes(source, 'validated_canonical_app_override')
+      assert_includes(source, "Open3.capture2('/usr/libexec/PlistBuddy'")
+      assert(!source.include?('`\"/usr/libexec/PlistBuddy\" -c \"Print :CFBundleIdentifier\"'),
+             'bundle paths must not be interpolated into a shell command')
+      true
+    end
   end
 
   test_category('No-keychain fallback domain') do

--- a/scripts/sane_test.rb
+++ b/scripts/sane_test.rb
@@ -1314,16 +1314,29 @@ class SaneTest
 
   def canonical_local_app_path
     env_override = ENV['SANETEST_CANONICAL_APP_PATH'] || ENV['SANEMASTER_CANONICAL_APP_PATH']
-    return File.expand_path(env_override) if env_override && !env_override.strip.empty?
-
     app_name = "#{@app_name}.app"
     system_app = File.join('/Applications', app_name)
     transient_app = File.expand_path(File.join(TRANSIENT_STAGE_ROOT, app_name))
+    if env_override && !env_override.strip.empty?
+      return validated_canonical_app_override(env_override, app_name: app_name, transient_app: transient_app)
+    end
 
     return system_app if system_app_dir_writable?
     return system_app if File.exist?(system_app)
 
     transient_app
+  end
+
+  def validated_canonical_app_override(raw_path, app_name:, transient_app:)
+    override_path = File.expand_path(raw_path.to_s)
+    approved_paths = [
+      File.join('/Applications', app_name),
+      File.expand_path(File.join('~/Applications', app_name)),
+      File.expand_path(transient_app)
+    ].uniq
+    return override_path if approved_paths.include?(override_path)
+
+    abort "   ❌ Unsafe canonical app override: #{override_path}. Expected one of: #{approved_paths.join(', ')}"
   end
 
   def local_app_copy_paths
@@ -1453,7 +1466,7 @@ class SaneTest
           # Avoid creating backup app bundle identities under /Applications.
           # TCC can retain those paths and keep stale camera attribution alive.
           unregister_launch_services_local(target_app_path)
-          FileUtils.rm_rf(target_app_path)
+          trash_local_path(target_app_path)
         end
         FileUtils.mv(temp_app_path, target_app_path)
         clear_gatekeeper_staging_attributes(target_app_path)
@@ -1475,7 +1488,10 @@ class SaneTest
     info_plist = File.join(app_path, 'Contents', 'Info.plist')
     return nil unless File.exist?(info_plist)
 
-    bundle_id = `"/usr/libexec/PlistBuddy" -c "Print :CFBundleIdentifier" "#{info_plist}" 2>/dev/null`.strip
+    bundle_id, status = Open3.capture2('/usr/libexec/PlistBuddy', '-c', 'Print :CFBundleIdentifier', info_plist)
+    return nil unless status.success?
+
+    bundle_id = bundle_id.strip
     return nil if bundle_id.empty?
 
     bundle_id

--- a/scripts/sanemaster/test_mode.rb
+++ b/scripts/sanemaster/test_mode.rb
@@ -9,6 +9,19 @@ module SaneMasterModules
 
     SANEAPPS_TEST_MODE_APPS = %w[SaneBar SaneClick SaneClip SaneHosts SaneSales SaneVideo].freeze
     SIGNED_RELEASE_RUNTIME_APPS = %w[SaneClip].freeze
+    SIGNING_SECRET_ENV_KEYS = %w[
+      ASC_AUTH_KEY_ID
+      ASC_AUTH_ISSUER_ID
+      ASC_AUTH_KEY_PATH
+      ASC_KEY_ID
+      ASC_ISSUER_ID
+      ASC_KEY_PATH
+      SANEBAR_KEYCHAIN_PATH
+      SANEBAR_KEYCHAIN_PASSWORD
+      KEYCHAIN_PATH
+      KEYCHAIN_PASSWORD
+      KEYCHAIN_PASS
+    ].freeze
 
     def project_name
       @project_name ||= if respond_to?(:config_value, true)
@@ -294,7 +307,7 @@ module SaneMasterModules
       transient_app = transient_local_app_path
 
       if env_override && !env_override.strip.empty?
-        override_path = File.expand_path(env_override)
+        override_path = validated_canonical_app_override(env_override, app_name: app_name, transient_app: transient_app)
         if unsigned_fallback_active? && override_path.start_with?('/Applications/')
           puts "⚠️  Ignoring SANEMASTER_CANONICAL_APP_PATH=#{override_path} during unsigned fallback."
           puts "   Using a transient non-indexed staging path instead to avoid replacing a signed /Applications install."
@@ -310,6 +323,19 @@ module SaneMasterModules
       return system_app if File.exist?(system_app)
 
       system_app
+    end
+
+    def validated_canonical_app_override(raw_path, app_name:, transient_app:)
+      override_path = File.expand_path(raw_path.to_s)
+      approved_paths = [
+        File.join('/Applications', app_name),
+        File.expand_path(File.join('~/Applications', app_name)),
+        File.expand_path(transient_app)
+      ].uniq
+      return override_path if approved_paths.include?(override_path)
+
+      raise ArgumentError,
+            "Unsafe canonical app override: #{override_path}. Expected one of: #{approved_paths.join(', ')}"
     end
 
     def stage_to_canonical_local_app_path(source_app_path)
@@ -375,7 +401,7 @@ module SaneMasterModules
           if File.exist?(target_app_path)
             # Avoid creating backup app bundle identities under /Applications.
             # TCC can retain those paths and keep stale camera attribution alive.
-            FileUtils.rm_rf(target_app_path)
+            trash_local_path(target_app_path)
           end
 
           FileUtils.mv(temp_app_path, target_app_path)
@@ -603,7 +629,7 @@ module SaneMasterModules
     def codesign_authority_lines(app_path)
       return [] unless app_path && File.exist?(app_path)
 
-      output = `codesign -dv --verbose=2 "#{app_path}" 2>&1`
+      output, = Open3.capture2e('codesign', '-dv', '--verbose=2', app_path)
       output.lines.map(&:strip).grep(/\AAuthority=/)
     end
 
@@ -616,7 +642,7 @@ module SaneMasterModules
     end
 
     def ad_hoc_signed?(app_path)
-      output = `codesign -dv --verbose=4 "#{app_path}" 2>&1`
+      output, = Open3.capture2e('codesign', '-dv', '--verbose=4', app_path)
       output.include?('Signature=adhoc')
     end
 
@@ -741,7 +767,10 @@ module SaneMasterModules
       info_plist = File.join(app_path, 'Contents', 'Info.plist')
       return nil unless File.exist?(info_plist)
 
-      bundle_id = `"/usr/libexec/PlistBuddy" -c "Print :CFBundleIdentifier" "#{info_plist}" 2>/dev/null`.strip
+      bundle_id, status = Open3.capture2('/usr/libexec/PlistBuddy', '-c', 'Print :CFBundleIdentifier', info_plist)
+      return nil unless status.success?
+
+      bundle_id = bundle_id.strip
       return nil if bundle_id.empty?
 
       bundle_id
@@ -1119,7 +1148,8 @@ module SaneMasterModules
 
         key, raw_value = text.split('=', 2)
         key = key.to_s.strip
-        next if key.empty? || ENV.key?(key)
+        next unless SIGNING_SECRET_ENV_KEYS.include?(key)
+        next if ENV.key?(key)
 
         value = raw_value.to_s.strip
         if value.start_with?('"') && value.end_with?('"') && value.length >= 2

--- a/scripts/sanemaster/test_mode_test.rb
+++ b/scripts/sanemaster/test_mode_test.rb
@@ -171,6 +171,58 @@ exit(run_tests('SaneMaster Test Mode Fallback Tests') do
       saved_fixed_home.nil? ? ENV.delete('CFFIXED_USER_HOME') : ENV['CFFIXED_USER_HOME'] = saved_fixed_home
     end
 
+    test('canonical app override rejects arbitrary directories') do
+      saved_override = ENV['SANEMASTER_CANONICAL_APP_PATH']
+
+      Dir.mktmpdir('sanemaster-unsafe-stage') do |dir|
+        File.write(File.join(dir, '.saneprocess'), "name: SaneHosts\nscheme: SaneHosts\n")
+        ENV['SANEMASTER_CANONICAL_APP_PATH'] = dir
+
+        error = Dir.chdir(dir) do
+          begin
+            TestModeHarness.new.send(:canonical_local_app_path)
+            nil
+          rescue ArgumentError => e
+            e
+          end
+        end
+
+        assert(error, 'arbitrary override must fail closed')
+        assert_includes(error.message, 'Unsafe canonical app override')
+      end
+
+      true
+    ensure
+      saved_override.nil? ? ENV.delete('SANEMASTER_CANONICAL_APP_PATH') : ENV['SANEMASTER_CANONICAL_APP_PATH'] = saved_override
+    end
+
+    test('signing secret loader imports only signing credentials') do
+      saved_home = ENV['HOME']
+      saved_signing = ENV.delete('ASC_AUTH_KEY_ID')
+      saved_unrelated = ENV.delete('LEMONSQUEEZY_API_KEY')
+
+      Dir.mktmpdir('sanemaster-signing-secrets') do |dir|
+        secrets_dir = File.join(dir, '.config', 'saneprocess')
+        FileUtils.mkdir_p(secrets_dir)
+        File.write(
+          File.join(secrets_dir, 'secrets.env'),
+          "ASC_AUTH_KEY_ID=TEST_KEY\nLEMONSQUEEZY_API_KEY=must_not_load\n"
+        )
+        ENV['HOME'] = dir
+
+        TestModeHarness.new.send(:load_saneprocess_secrets_env)
+
+        assert_eq(ENV['ASC_AUTH_KEY_ID'], 'TEST_KEY')
+        assert_eq(ENV['LEMONSQUEEZY_API_KEY'], nil)
+      end
+
+      true
+    ensure
+      ENV['HOME'] = saved_home
+      saved_signing.nil? ? ENV.delete('ASC_AUTH_KEY_ID') : ENV['ASC_AUTH_KEY_ID'] = saved_signing
+      saved_unrelated.nil? ? ENV.delete('LEMONSQUEEZY_API_KEY') : ENV['LEMONSQUEEZY_API_KEY'] = saved_unrelated
+    end
+
     test('no-keychain launch state is passed through LaunchServices open') do
       result = subject.send(
         :open_launch_env_pairs,


### PR DESCRIPTION
## Summary
- constrain canonical staging overrides to exact app bundle paths
- replace shell-interpolated signature and plist reads with argument arrays
- move replaced bundles to Trash and limit imported secrets to signing credentials
- add destructive-path and secret-scope regressions

## Verification
- test_mode_test.rb 30/30
- app_test_mode_test.rb 42/42
- ruby -c scripts/sane_test.rb
- git diff --check