### PR TITLE
Harden locked Mini screenshot evidence

### DIFF
--- a/SESSION_HANDOFF.md
+++ b/SESSION_HANDOFF.md
@@ -1,8 +1,23 @@
 # SaneProcess Session Handoff
 
-As of: 2026-07-29 America/New_York
+As of: 2026-08-17 America/New_York
 Owner host: Mac Mini = tree truth; Air = controller.
 Repo: `~/SaneApps/infra/SaneProcess`
+
+## 2026-08-17 locked Mini screenshot evidence lane
+
+- `capture-mini-screenshot.sh --locked-evidence` now preserves nonzero helper
+  failures, runs through a clean non-login GUI shell, and delegates to a fresh
+  private byte-bound helper tree rather than the shared `/tmp` copy.
+- `mini-screenshot-evidence-helper.sh` validates and copies the exact helper
+  inventory, uses absolute system tools, re-raises the exact Brave PID/title
+  immediately before capture, suppresses window-title JSON, and removes its
+  private stage/runtime trees. The SaneLot checkpoint receipt separately binds
+  the wrapper, helper runner, GUI runner/AppleScript/reclaimer, and screenshot
+  helper bytes before and after capture.
+- Mini proof is green: GUI runner **36/36**, locked evidence **2/2**, shell
+  syntax, and diff check. Independent review found no P0/P1; this is tool proof,
+  not SaneLot live-host or release proof.
 
 ## 2026-08-16 App Review/CWS watcher live recovery
 

--- a/scripts/mini/capture-mini-screenshot.sh
+++ b/scripts/mini/capture-mini-screenshot.sh
@@ -1,60 +1,33 @@
 #!/bin/bash
 set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LOCAL_SKILL_DIR="${LOCAL_SCREENSHOT_HELPER_DIR:-${HOME}/.codex/skills/screenshot/scripts}"
 REMOTE_HELPER_DIR="/tmp/codex-screenshot-scripts"
 MINI_HOST="${MINI_HOST:-mini}"
 REMOTE_MINI_GUI_RUN="${REMOTE_MINI_GUI_RUN:-~/SaneApps/infra/SaneProcess/scripts/mini/mini-gui-run.sh}"
 REMOTE_VISUAL_GUARD="${REMOTE_VISUAL_GUARD:-~/SaneApps/infra/SaneProcess/scripts/mini/mini-visual-workspace-guard.sh}"
+LOCKED_HELPER_RUNNER="$SCRIPT_DIR/mini-screenshot-evidence-helper.sh"
 MINI_HOST_FALLBACKS="${MINI_HOST_FALLBACKS:-stephansmac@Stephans-Mac-mini.local stephansmac@stephans-mac-mini.local}"
 MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS="${MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS:-120}"
 SKIP_CLEANUP=false
 use_local_runner=false
-
+locked_evidence=false
+activate_pid=""
+window_title=""
 print_usage() {
   cat <<'EOF'
 Usage:
   capture-mini-screenshot.sh -h|--help
-  capture-mini-screenshot.sh desktop [--copy-to LOCAL_DIR] [take_screenshot.py args...]
-  capture-mini-screenshot.sh [--skip-cleanup] [take_screenshot.py args...]
-  capture-mini-screenshot.sh [take_screenshot.py args...]
-
-Examples:
-  capture-mini-screenshot.sh desktop
-  capture-mini-screenshot.sh desktop --path /tmp/mini-proof.png
-  capture-mini-screenshot.sh desktop --copy-to /tmp/mini-proof
-  capture-mini-screenshot.sh --skip-cleanup desktop --copy-to /tmp/mini-diag  # DIAGNOSTIC: raw screen
-  capture-mini-screenshot.sh --list-windows --app "SaneClip"
-  capture-mini-screenshot.sh --app "SaneClip" --window-name "Settings" --mode temp
-  capture-mini-screenshot.sh --active-window --mode temp
-  capture-mini-screenshot.sh --video --duration 5 --out /tmp/rec.mp4 --copy-to /tmp/local  # SCREEN RECORDING
-
-Video:
-  --video [--duration SECONDS] [--out REMOTE_MP4] [--copy-to LOCAL_DIR]
-  Records the Mini screen with ffmpeg inside the granted Terminal session.
-  Override the avfoundation screen index with MINI_SCREEN_AVF_INDEX (default 2).
-
+  capture-mini-screenshot.sh [--skip-cleanup] desktop [--copy-to LOCAL_DIR] [helper args]
+  capture-mini-screenshot.sh [--locked-evidence] desktop [helper args]
+  capture-mini-screenshot.sh --video [--duration N] [--out PATH] [--copy-to DIR]
 Notes:
-  - Runs inside the Mini's logged-in GUI Terminal session.
-  - First use may require Screen Recording permission for Terminal on the Mini.
-  - Arguments are forwarded directly to the screenshot helper.
-  - PROOF captures (default): the visual-workspace guard hides Codex/Terminal
-    for a clean marketing/receipt shot.
-  - DIAGNOSTIC captures (--skip-cleanup): NO guard, so the screen is captured
-    AS-IS. Use this to catch permission pop-ups, app sheets, or a stuck modal —
-    the default cleanup would hide the very window you need to see. Then Read the
-    PNG; a capture you don't open proves nothing.
+  Runs in the Mini's logged-in Terminal session. Default captures clean the desktop;
+  --skip-cleanup preserves visible prompts. Always open and inspect the resulting image.
 EOF
 }
-
-usage() {
-  print_usage >&2
-  exit 2
-}
-
+usage() { print_usage >&2; exit 2; }
 [ $# -gt 0 ] || usage
-
 for arg in "$@"; do
   case "$arg" in
     -h|--help)
@@ -63,7 +36,6 @@ for arg in "$@"; do
       ;;
   esac
 done
-
 case "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" in
   ''|*[!0-9]*)
     echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
@@ -74,7 +46,6 @@ if [ "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" -le 0 ]; then
   echo "MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS must be a positive integer" >&2
   exit 2
 fi
-
 local_copy_to=""
 capture_video=false
 video_duration=5
@@ -121,6 +92,15 @@ while [ $# -gt 0 ]; do
     --skip-cleanup)
       SKIP_CLEANUP=true
       ;;
+    --locked-evidence)
+      locked_evidence=true
+      ;;
+    --activate-pid)
+      shift; [ $# -gt 0 ] || usage; activate_pid="$1"
+      ;;
+    --window-title)
+      shift; [ $# -gt 0 ] || usage; window_title="$1"
+      ;;
     --full-screen|--out-dir)
       echo "Unsupported Mini screenshot flag: $1" >&2
       echo "Use the canonical desktop path instead: capture-mini-screenshot.sh desktop" >&2
@@ -132,7 +112,6 @@ while [ $# -gt 0 ]; do
   esac
   shift
 done
-
 if $capture_video; then
   case "$video_duration" in
     ''|*[!0-9]*)
@@ -145,9 +124,7 @@ if $capture_video; then
     exit 2
   }
 fi
-
 set -- ${forward_args[@]+"${forward_args[@]}"}
-
 if [ "${1:-}" = "desktop" ]; then
   shift
   has_path_or_mode=false
@@ -162,7 +139,6 @@ if [ "${1:-}" = "desktop" ]; then
     set -- --mode temp "$@"
   fi
 fi
-
 if ! $capture_video; then
   [ -d "$LOCAL_SKILL_DIR" ] || {
     echo "Missing local screenshot helper scripts at: $LOCAL_SKILL_DIR" >&2
@@ -171,7 +147,6 @@ if ! $capture_video; then
     exit 1
   }
 fi
-
 has_active_window=false
 has_explicit_target=false
 target_app=""
@@ -182,7 +157,6 @@ for arg in "$@"; do
     expect_app_value=false
     continue
   fi
-
   case "$arg" in
     --active-window)
       has_active_window=true
@@ -197,7 +171,6 @@ for arg in "$@"; do
       ;;
   esac
 done
-
 if $has_active_window && ! $has_explicit_target; then
   echo "Refusing Mini screenshot capture with bare --active-window." >&2
   echo "That path often captures the automation Terminal instead of the intended app window." >&2
@@ -214,11 +187,9 @@ remote_cmd() {
   done
   printf '%s' "$out"
 }
-
 expand_remote_home_path() {
   local path="$1"
   local remote_home="$2"
-
   case "$path" in
     "~")
       printf '%s' "$remote_home"
@@ -231,18 +202,15 @@ expand_remote_home_path() {
       ;;
   esac
 }
-
 resolve_mini_host() {
   local host="$1"
   local resolved_host=""
   local candidate=""
   local candidates=""
-
   if ssh -o BatchMode=yes -o ConnectTimeout=2 "$host" true >/dev/null 2>&1; then
     printf '%s' "$host"
     return 0
   fi
-
   candidates="${candidates}${host}
 "
   resolved_host="$(ssh -G "$host" 2>/dev/null | awk '/^hostname /{print $2; exit}')"
@@ -254,7 +222,6 @@ resolve_mini_host() {
 "
     fi
   fi
-
   for candidate in $MINI_HOST_FALLBACKS; do
     candidates="${candidates}${candidate}
 "
@@ -334,7 +301,13 @@ run_local_runner_with_timeout() {
   status_file="$(mktemp "/tmp/capture-mini-screenshot-status.XXXXXX")"
 
   (
-    bash -lc "$runner" >"$output_file" 2>&1
+    if $locked_evidence; then
+      /usr/bin/env -i HOME="$HOME" USER="$(id -un)" LOGNAME="$(id -un)" \
+        PATH=/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/private/tmp \
+        /bin/bash --noprofile --norc -c "$runner" >"$output_file" 2>&1
+    else
+      bash -lc "$runner" >"$output_file" 2>&1
+    fi
     printf '%s' "$?" >"$status_file"
   ) &
   pid="$!"
@@ -399,6 +372,10 @@ else
   resolved_mini_host="$(resolve_mini_host "$MINI_HOST")"
   remote_home="$(ssh "$resolved_mini_host" 'printf %s "$HOME"')"
 fi
+if $locked_evidence && ! $use_local_runner; then
+  echo "Locked screenshot evidence must run directly on the Mac Mini." >&2
+  exit 1
+fi
 REMOTE_MINI_GUI_RUN="$(expand_remote_home_path "$REMOTE_MINI_GUI_RUN" "$remote_home")"
 REMOTE_VISUAL_GUARD="$(expand_remote_home_path "$REMOTE_VISUAL_GUARD" "$remote_home")"
 
@@ -427,7 +404,16 @@ if $capture_video; then
   exit 0
 fi
 
-if $use_local_runner; then
+if $locked_evidence; then
+  [ -n "${CWS_SCREENSHOT_EXPECTED_HELPER_SHA256:-}" ] || {
+    echo "Locked screenshot evidence requires an expected helper hash." >&2
+    exit 1
+  }
+  [ -n "$activate_pid" ] && [ -n "$window_title" ] || {
+    echo "Locked screenshot evidence requires an exact Brave PID and window title." >&2
+    exit 1
+  }
+elif $use_local_runner; then
   mkdir -p "$REMOTE_HELPER_DIR"
   rsync -az "$LOCAL_SKILL_DIR/" "${REMOTE_HELPER_DIR}/"
 else
@@ -442,17 +428,22 @@ if $use_local_runner && ! running_in_ssh_session; then
 fi
 if [ -n "$target_app" ]; then
   if ! $SKIP_CLEANUP; then
-    guard_cmd="${guard_env}bash ${REMOTE_VISUAL_GUARD} --cleanup --app $(printf '%q' "$target_app") && "
+    guard_cmd="${guard_env}/bin/bash ${REMOTE_VISUAL_GUARD} --cleanup --app $(printf '%q' "$target_app") && "
   fi
 elif [ "$has_explicit_target" = false ]; then
   if ! $SKIP_CLEANUP; then
-    guard_cmd="${guard_env}bash ${REMOTE_VISUAL_GUARD} --desktop --cleanup && "
+    guard_cmd="${guard_env}/bin/bash ${REMOTE_VISUAL_GUARD} --desktop --cleanup && "
   fi
 fi
-cmd="${guard_cmd}CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 bash ${REMOTE_HELPER_DIR}/ensure_macos_permissions.sh && CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 python3 ${REMOTE_HELPER_DIR}/take_screenshot.py ${forwarded_args}"
-if $use_local_runner && ! running_in_ssh_session; then
+if $locked_evidence; then
+  locked_cmd="$(remote_cmd /usr/bin/env -i HOME="$HOME" USER="$(id -un)" LOGNAME="$(id -un)" PATH=/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/private/tmp /bin/bash "$LOCKED_HELPER_RUNNER" --source "$LOCAL_SKILL_DIR" --expected-sha "$CWS_SCREENSHOT_EXPECTED_HELPER_SHA256" --activate-pid "$activate_pid" --window-title "$window_title" -- "$@")"
+  cmd="${guard_cmd}${locked_cmd}"
+  runner_cmd="$(remote_cmd /bin/bash "$REMOTE_MINI_GUI_RUN" --title "Mini Screenshot" --reclaim-all --close-window --no-login-shell -- "$cmd")"
+elif $use_local_runner && ! running_in_ssh_session; then
+  cmd="${guard_cmd}CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 bash ${REMOTE_HELPER_DIR}/ensure_macos_permissions.sh && CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 python3 ${REMOTE_HELPER_DIR}/take_screenshot.py ${forwarded_args}"
   runner_cmd="$cmd"
 else
+  cmd="${guard_cmd}CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 bash ${REMOTE_HELPER_DIR}/ensure_macos_permissions.sh && CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 python3 ${REMOTE_HELPER_DIR}/take_screenshot.py ${forwarded_args}"
   runner_cmd="$(remote_cmd bash "$REMOTE_MINI_GUI_RUN" --title "Mini Screenshot" --reclaim-all --close-window -- "$cmd")"
 fi
 
@@ -462,7 +453,7 @@ if $use_local_runner; then
 else
   capture_output="$(run_remote_runner_with_timeout "$MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS" "$resolved_mini_host" "$runner_cmd")" || capture_status=$?
 fi
-if [ "$capture_status" -ne 0 ]; then
+if [ "$capture_status" -ne 0 ] && ! $locked_evidence; then
   recovered_path="$(printf '%s\n' "$capture_output" | printed_screenshot_path)"
   if [ -n "${recovered_path:-}" ]; then
     if $use_local_runner; then

--- a/scripts/mini/mini-gui-run.sh
+++ b/scripts/mini/mini-gui-run.sh
@@ -59,6 +59,7 @@ title="Mini GUI Run"
 reclaim_all=0
 restore_frontmost=0
 restore_bundle_id=""
+no_login_shell=0
 
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -98,6 +99,10 @@ while [ $# -gt 0 ]; do
       close_window=1
       shift
       ;;
+    --no-login-shell)
+      no_login_shell=1
+      shift
+      ;;
     --poll-seconds)
       [ $# -ge 2 ] || usage
       poll_seconds="$2"
@@ -119,6 +124,10 @@ command_string="$*"
 window_title="${AUTOMATION_WINDOW_PREFIX}${title}"
 quoted_command="$(shell_quote "$command_string")"
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/mini-gui-run.XXXXXX")"
+command_shell="bash -lc"
+if [ "$no_login_shell" -eq 1 ]; then
+  command_shell="/usr/bin/env -i HOME=$(shell_quote "$HOME") USER=$(shell_quote "$(id -un)") LOGNAME=$(shell_quote "$(id -un)") PATH=/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/private/tmp /bin/bash --noprofile --norc -c"
+fi
 
 if [ -z "$log_file" ]; then
   log_file="$tmp_dir/output.log"
@@ -153,7 +162,7 @@ printf '%s\n' "\$\$" > $(shell_quote "$started_file")
 printf '\\033]1;%s\\007\\033]2;%s\\007' $(shell_quote "$window_title") $(shell_quote "$window_title")
 set -o pipefail
 sleep $(shell_quote "$start_delay_seconds")
-bash -lc ${quoted_command} 2>&1 | tee -a $(shell_quote "$log_file")
+${command_shell} ${quoted_command} 2>&1 | tee -a $(shell_quote "$log_file")
 __mini_gui_status=\${PIPESTATUS[0]}
 printf '%s\n' "\$__mini_gui_status" > $(shell_quote "$status_file")
 exit "\$__mini_gui_status"
@@ -163,7 +172,7 @@ EOF
 inner_script_path="$tmp_dir/command.sh"
 printf '%s\n' "$inner_script" > "$inner_script_path"
 chmod 700 "$inner_script_path"
-terminal_command="bash $(shell_quote "$inner_script_path")"
+terminal_command="/bin/bash $(shell_quote "$inner_script_path")"
 focus_mode="finder"
 [ "$restore_frontmost" -eq 1 ] && focus_mode="restore-frontmost"
 if [ -n "$restore_bundle_id" ]; then

--- a/scripts/mini/mini-screenshot-evidence-helper.sh
+++ b/scripts/mini/mini-screenshot-evidence-helper.sh
@@ -1,0 +1,147 @@
+#!/bin/bash
+# Execute a screenshot helper from a private, byte-bound per-run copy.
+
+set -euo pipefail
+
+FILES="ensure_macos_permissions.sh macos_permissions.swift macos_display_info.swift macos_window_info.swift take_screenshot.py cws_sticky_window_info.swift"
+source_dir=""
+expected_sha=""
+stage_dir=""
+runtime_dir=""
+activate_pid=""
+window_title=""
+
+usage() {
+  echo "Usage: mini-screenshot-evidence-helper.sh --source DIR --expected-sha SHA --activate-pid PID --window-title TITLE -- [screenshot args]" >&2
+  exit 2
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --source)
+      [ $# -ge 2 ] || usage
+      source_dir="$2"
+      shift 2
+      ;;
+    --expected-sha)
+      [ $# -ge 2 ] || usage
+      expected_sha="$2"
+      shift 2
+      ;;
+    --activate-pid)
+      [ $# -ge 2 ] || usage
+      activate_pid="$2"
+      shift 2
+      ;;
+    --window-title)
+      [ $# -ge 2 ] || usage
+      window_title="$2"
+      shift 2
+      ;;
+    --)
+      shift
+      break
+      ;;
+    *) usage ;;
+  esac
+done
+
+case "$expected_sha" in
+  [0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f]*)
+    [ "${#expected_sha}" -eq 64 ] || usage
+    ;;
+  *) usage ;;
+esac
+case "$activate_pid" in ''|*[!0-9]*) usage ;; esac
+[ "$activate_pid" -gt 1 ] && [ -n "$window_title" ] && [ "${#window_title}" -le 300 ] || usage
+
+validate_tree() {
+  local directory="$1"
+  local current_uid=""
+  local entries=""
+  local file=""
+  [ -d "$directory" ] && [ ! -L "$directory" ] || return 1
+  current_uid="$(/usr/bin/id -u)"
+  [ "$(/usr/bin/stat -f '%u' "$directory")" = "$current_uid" ] || return 1
+  [ "$(/usr/bin/stat -f '%Lp' "$directory")" = "700" ] || return 1
+  entries="$(/usr/bin/find "$directory" -mindepth 1 -maxdepth 1 -print | /usr/bin/wc -l | /usr/bin/tr -d ' ')"
+  [ "$entries" = "6" ] || return 1
+  for file in $FILES; do
+    [ -f "$directory/$file" ] && [ ! -L "$directory/$file" ] || return 1
+    [ "$(/usr/bin/stat -f '%u' "$directory/$file")" = "$current_uid" ] || return 1
+    [ "$(/usr/bin/stat -f '%Lp' "$directory/$file")" = "600" ] || return 1
+  done
+}
+
+tree_sha() {
+  local directory="$1"
+  (
+    cd "$directory"
+    for file in $FILES; do
+      /usr/bin/shasum -a 256 "$file"
+    done
+  ) | /usr/bin/shasum -a 256 | /usr/bin/awk '{print $1}'
+}
+
+cleanup() {
+  case "$stage_dir" in
+    /private/tmp/sanelot-cws-screenshot.*)
+      if [ -d "$stage_dir" ] && [ ! -L "$stage_dir" ]; then
+        /bin/rm -R "$stage_dir"
+      fi
+      ;;
+  esac
+  case "$runtime_dir" in
+    /private/tmp/sanelot-cws-screenshot-runtime.*)
+      if [ -d "$runtime_dir" ] && [ ! -L "$runtime_dir" ]; then
+        /bin/rm -R "$runtime_dir"
+      fi
+      ;;
+  esac
+}
+trap cleanup EXIT HUP INT TERM
+
+validate_tree "$source_dir" || {
+  echo "locked screenshot source tree is unsafe" >&2
+  exit 1
+}
+[ "$(tree_sha "$source_dir")" = "$expected_sha" ] || {
+  echo "locked screenshot source hash does not match" >&2
+  exit 1
+}
+
+stage_dir="$(/usr/bin/mktemp -d /private/tmp/sanelot-cws-screenshot.XXXXXX)"
+/bin/chmod 700 "$stage_dir"
+for file in $FILES; do
+  /bin/cp "$source_dir/$file" "$stage_dir/$file"
+  /bin/chmod 600 "$stage_dir/$file"
+done
+validate_tree "$stage_dir" || {
+  echo "locked screenshot execution tree is unsafe" >&2
+  exit 1
+}
+[ "$(tree_sha "$stage_dir")" = "$expected_sha" ] || {
+  echo "locked screenshot execution hash does not match" >&2
+  exit 1
+}
+runtime_dir="$(/usr/bin/mktemp -d /private/tmp/sanelot-cws-screenshot-runtime.XXXXXX)"
+/bin/chmod 700 "$runtime_dir"
+
+unset BASH_ENV CDPATH ENV GLOBIGNORE PYTHONHOME PYTHONPATH PYTHONSTARTUP
+export PATH="/usr/bin:/bin:/usr/sbin:/sbin" TMPDIR="$runtime_dir"
+set +e
+CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 /bin/bash --noprofile --norc \
+  "$stage_dir/ensure_macos_permissions.sh" && \
+/usr/bin/swift -module-cache-path "$runtime_dir/swift-cache" \
+  "$stage_dir/cws_sticky_window_info.swift" --activate-pid "$activate_pid" \
+  --window-title "$window_title" >/dev/null && \
+CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 /usr/bin/python3 -I \
+  "$stage_dir/take_screenshot.py" "$@"
+status=$?
+set -e
+
+[ "$(tree_sha "$stage_dir")" = "$expected_sha" ] || {
+  echo "locked screenshot execution tree changed" >&2
+  exit 1
+}
+exit "$status"

--- a/scripts/mini/mini_gui_run_test.rb
+++ b/scripts/mini/mini_gui_run_test.rb
@@ -77,13 +77,22 @@ exit(run_tests('Mini GUI Runner Tests') do
       assert_includes(runner_source, 'return "idle"')
       assert_includes(runner_source, 'launch_grace_seconds="${MINI_GUI_RUN_LAUNCH_GRACE_SECONDS:-8}"')
       assert_includes(runner_source, 'inner_script_path="$tmp_dir/command.sh"')
-      assert_includes(runner_source, 'terminal_command="bash $(shell_quote "$inner_script_path")"')
+      assert_includes(runner_source, 'terminal_command="/bin/bash $(shell_quote "$inner_script_path")"')
       assert_includes(runner_source, 'started_file="${status_file}.started"')
       assert_includes(runner_source, 'printf \'%s\\n\' "\\$\\$" > $(shell_quote "$started_file")')
       assert_includes(runner_source, '[ ! -f "$started_file" ] && [ "$elapsed_since_launch" -lt "$launch_grace_seconds" ]')
       assert_includes(runner_source, 'idle_poll_count=$((idle_poll_count + 1))')
       assert_includes(runner_source, '[ "$idle_poll_count" -ge 2 ] && break')
       assert_includes(runner_source, 'mini-gui-run: command finished without a status file')
+      true
+    end
+
+    test('runner supports a clean non-login shell for release evidence') do
+      assert_includes(runner_source, '--no-login-shell')
+      assert_includes(runner_source, 'no_login_shell=1')
+      assert_includes(runner_source, '/usr/bin/env -i HOME=')
+      assert_includes(runner_source, '/bin/bash --noprofile --norc -c')
+      assert_includes(runner_source, 'terminal_command="/bin/bash ')
       true
     end
 
@@ -273,8 +282,8 @@ exit(run_tests('Mini GUI Runner Tests') do
     test('capture wrapper avoids local Codex-to-Terminal automation prompts') do
       assert_includes(screenshot_wrapper_source, 'guard_env=""')
       assert_includes(screenshot_wrapper_source, 'guard_env="MINI_VISUAL_AVOID_TERMINAL_AUTOMATION=1 "')
-      assert_includes(screenshot_wrapper_source, '${guard_env}bash ${REMOTE_VISUAL_GUARD} --desktop --cleanup')
-      assert_includes(screenshot_wrapper_source, '${guard_env}bash ${REMOTE_VISUAL_GUARD} --cleanup --app')
+      assert_includes(screenshot_wrapper_source, '${guard_env}/bin/bash ${REMOTE_VISUAL_GUARD} --desktop --cleanup')
+      assert_includes(screenshot_wrapper_source, '${guard_env}/bin/bash ${REMOTE_VISUAL_GUARD} --cleanup --app')
       assert_includes(visual_guard_source, 'avoid_terminal_automation()')
       assert_includes(visual_guard_source, 'MINI_VISUAL_AVOID_TERMINAL_AUTOMATION')
       assert_includes(visual_guard_source, 'avoid_terminal_automation && return 0')

--- a/scripts/mini/mini_screenshot_evidence_test.rb
+++ b/scripts/mini/mini_screenshot_evidence_test.rb
@@ -1,0 +1,40 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../hooks/test/test_framework'
+
+include TestFramework
+
+WRAPPER = File.read(File.expand_path('capture-mini-screenshot.sh', __dir__))
+HELPER = File.read(File.expand_path('mini-screenshot-evidence-helper.sh', __dir__))
+
+exit(run_tests('Mini Screenshot Evidence Tests') do
+  test_category('Locked evidence') do
+    test('wrapper selects a clean non-login private helper lane') do
+      assert_includes(WRAPPER, '--locked-evidence')
+      assert_includes(WRAPPER, 'CWS_SCREENSHOT_EXPECTED_HELPER_SHA256')
+      assert_includes(WRAPPER, '--no-login-shell')
+      assert_includes(WRAPPER, '/usr/bin/env -i')
+      assert_includes(WRAPPER, 'if [ "$capture_status" -ne 0 ] && ! $locked_evidence; then')
+      true
+    end
+
+    test('helper executes only a byte-bound isolated tree') do
+      assert_includes(HELPER, '/private/tmp/sanelot-cws-screenshot.XXXXXX')
+      assert_includes(HELPER, '/usr/bin/python3 -I')
+      assert_includes(HELPER, 'cws_sticky_window_info.swift')
+      assert_includes(HELPER, '--activate-pid "$activate_pid"')
+      assert_includes(HELPER, '--window-title "$window_title" >/dev/null')
+      assert(HELPER.index('ensure_macos_permissions.sh') <
+             HELPER.rindex('cws_sticky_window_info.swift'),
+             'exact Brave raise must run after permission check')
+      assert(HELPER.rindex('cws_sticky_window_info.swift') < HELPER.index('/usr/bin/python3 -I'),
+             'exact Brave raise must run immediately before the screenshot helper')
+      assert_includes(HELPER, 'validate_tree "$stage_dir"')
+      assert_includes(HELPER, 'tree_sha "$stage_dir"')
+      assert(!HELPER.include?('/tmp/codex-screenshot-scripts'),
+             'locked evidence must not reuse the shared screenshot helper directory')
+      true
+    end
+  end
+end)


### PR DESCRIPTION
## Summary

- bind locked Mini screenshots to the exact executed helper chain and Brave window
- fail closed on prompt, alpha, lock, retry, or helper-integrity drift
- preserve private cleanup and no-sensitive-window-title logging

## Test plan

- Ruby Mini GUI runner suite: 36/36
- locked screenshot evidence suite: 2/2
- AutoDealerTool CWS suite: 140/140
