### PR TITLE
Support locked transient popup screenshots

### DIFF
--- a/scripts/mini/capture-mini-screenshot.sh
+++ b/scripts/mini/capture-mini-screenshot.sh
@@ -11,7 +11,7 @@ MINI_HOST_FALLBACKS="${MINI_HOST_FALLBACKS:-stephansmac@Stephans-Mac-mini.local 
 MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS="${MINI_SCREENSHOT_CAPTURE_TIMEOUT_SECONDS:-120}"
 SKIP_CLEANUP=false
 use_local_runner=false
-locked_evidence=false
+locked_evidence=false preserve_frontmost=false
 activate_pid=""
 window_title=""
 print_usage() {
@@ -19,7 +19,7 @@ print_usage() {
 Usage:
   capture-mini-screenshot.sh -h|--help
   capture-mini-screenshot.sh [--skip-cleanup] desktop [--copy-to LOCAL_DIR] [helper args]
-  capture-mini-screenshot.sh [--locked-evidence] desktop [helper args]
+  capture-mini-screenshot.sh [--locked-evidence] [--preserve-frontmost | --activate-pid PID --window-title TITLE] desktop [helper args]
   capture-mini-screenshot.sh --video [--duration N] [--out PATH] [--copy-to DIR]
 Notes:
   Runs in the Mini's logged-in Terminal session. Default captures clean the desktop;
@@ -95,6 +95,7 @@ while [ $# -gt 0 ]; do
     --locked-evidence)
       locked_evidence=true
       ;;
+    --preserve-frontmost) preserve_frontmost=true ;;
     --activate-pid)
       shift; [ $# -gt 0 ] || usage; activate_pid="$1"
       ;;
@@ -226,7 +227,6 @@ resolve_mini_host() {
     candidates="${candidates}${candidate}
 "
   done
-
   while IFS= read -r candidate; do
     [ -n "$candidate" ] || continue
     if ssh -o BatchMode=yes -o ConnectTimeout=3 "$candidate" true >/dev/null 2>&1; then
@@ -236,13 +236,11 @@ resolve_mini_host() {
   done <<EOF
 $candidates
 EOF
-
   echo "Could not reach the canonical Mini host." >&2
   echo "Tried: ${candidates[*]}" >&2
   echo "Fix ~/.ssh/config or set MINI_HOST=user@host; do not use ad hoc screenshot paths." >&2
   return 1
 }
-
 run_remote_runner_with_timeout() {
   local timeout_seconds="$1"
   local host="$2"
@@ -252,7 +250,6 @@ run_remote_runner_with_timeout() {
   local pid=""
   local elapsed=0
   local status=1
-
   output_file="$(mktemp "/tmp/capture-mini-screenshot-output.XXXXXX")"
   status_file="$(mktemp "/tmp/capture-mini-screenshot-status.XXXXXX")"
 
@@ -401,15 +398,17 @@ if $capture_video; then
   exit 0
 fi
 
+$preserve_frontmost && ! $locked_evidence && { echo "--preserve-frontmost requires --locked-evidence." >&2; exit 1; }
 if $locked_evidence; then
   [ -n "${CWS_SCREENSHOT_EXPECTED_HELPER_SHA256:-}" ] || {
     echo "Locked screenshot evidence requires an expected helper hash." >&2
     exit 1
   }
-  [ -n "$activate_pid" ] && [ -n "$window_title" ] || {
-    echo "Locked screenshot evidence requires an exact Brave PID and window title." >&2
-    exit 1
-  }
+  if $preserve_frontmost; then
+    [ -z "$activate_pid" ] && [ -z "$window_title" ] || { echo "Locked preserve-frontmost evidence cannot also activate a window." >&2; exit 1; }
+  else
+    [ -n "$activate_pid" ] && [ -n "$window_title" ] || { echo "Locked screenshot evidence requires an exact Brave PID and window title." >&2; exit 1; }
+  fi
 elif $use_local_runner; then
   mkdir -p "$REMOTE_HELPER_DIR"
   rsync -az "$LOCAL_SKILL_DIR/" "${REMOTE_HELPER_DIR}/"
@@ -433,7 +432,8 @@ elif [ "$has_explicit_target" = false ]; then
   fi
 fi
 if $locked_evidence; then
-  locked_cmd="$(remote_cmd /usr/bin/env -i HOME="$HOME" USER="$(id -un)" LOGNAME="$(id -un)" PATH=/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/private/tmp /bin/bash "$LOCKED_HELPER_RUNNER" --source "$LOCAL_SKILL_DIR" --expected-sha "$CWS_SCREENSHOT_EXPECTED_HELPER_SHA256" --activate-pid "$activate_pid" --window-title "$window_title" -- "$@")"
+  $preserve_frontmost && locked_window_args=(--preserve-frontmost) || locked_window_args=(--activate-pid "$activate_pid" --window-title "$window_title")
+  locked_cmd="$(remote_cmd /usr/bin/env -i HOME="$HOME" USER="$(id -un)" LOGNAME="$(id -un)" PATH=/usr/bin:/bin:/usr/sbin:/sbin TMPDIR=/private/tmp /bin/bash "$LOCKED_HELPER_RUNNER" --source "$LOCAL_SKILL_DIR" --expected-sha "$CWS_SCREENSHOT_EXPECTED_HELPER_SHA256" "${locked_window_args[@]}" -- "$@")"
   cmd="${guard_cmd}${locked_cmd}"
   if running_in_ssh_session; then
     runner_cmd="$(remote_cmd /bin/bash "$REMOTE_MINI_GUI_RUN" --title "Mini Screenshot" --reclaim-all --close-window --no-login-shell -- "$cmd")"

--- a/scripts/mini/mini-screenshot-evidence-helper.sh
+++ b/scripts/mini/mini-screenshot-evidence-helper.sh
@@ -10,9 +10,10 @@ stage_dir=""
 runtime_dir=""
 activate_pid=""
 window_title=""
+preserve_frontmost=false
 
 usage() {
-  echo "Usage: mini-screenshot-evidence-helper.sh --source DIR --expected-sha SHA --activate-pid PID --window-title TITLE -- [screenshot args]" >&2
+  echo "Usage: mini-screenshot-evidence-helper.sh --source DIR --expected-sha SHA [--preserve-frontmost | --activate-pid PID --window-title TITLE] -- [screenshot args]" >&2
   exit 2
 }
 
@@ -38,6 +39,10 @@ while [ $# -gt 0 ]; do
       window_title="$2"
       shift 2
       ;;
+    --preserve-frontmost)
+      preserve_frontmost=true
+      shift
+      ;;
     --)
       shift
       break
@@ -52,8 +57,12 @@ case "$expected_sha" in
     ;;
   *) usage ;;
 esac
-case "$activate_pid" in ''|*[!0-9]*) usage ;; esac
-[ "$activate_pid" -gt 1 ] && [ -n "$window_title" ] && [ "${#window_title}" -le 300 ] || usage
+if $preserve_frontmost; then
+  [ -z "$activate_pid" ] && [ -z "$window_title" ] || usage
+else
+  case "$activate_pid" in ''|*[!0-9]*) usage ;; esac
+  [ "$activate_pid" -gt 1 ] && [ -n "$window_title" ] && [ "${#window_title}" -le 300 ] || usage
+fi
 
 validate_tree() {
   local directory="$1"
@@ -129,12 +138,16 @@ runtime_dir="$(/usr/bin/mktemp -d /private/tmp/sanelot-cws-screenshot-runtime.XX
 
 unset BASH_ENV CDPATH ENV GLOBIGNORE PYTHONHOME PYTHONPATH PYTHONSTARTUP
 export PATH="/usr/bin:/bin:/usr/sbin:/sbin" TMPDIR="$runtime_dir"
+activate_exact_window() {
+  $preserve_frontmost && return 0
+  /usr/bin/swift -module-cache-path "$runtime_dir/swift-cache" \
+    "$stage_dir/cws_sticky_window_info.swift" --activate-pid "$activate_pid" \
+    --window-title "$window_title" >/dev/null
+}
 set +e
 CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 /bin/bash --noprofile --norc \
   "$stage_dir/ensure_macos_permissions.sh" && \
-/usr/bin/swift -module-cache-path "$runtime_dir/swift-cache" \
-  "$stage_dir/cws_sticky_window_info.swift" --activate-pid "$activate_pid" \
-  --window-title "$window_title" >/dev/null && \
+activate_exact_window && \
 CODEX_SCREENSHOT_NO_PERMISSION_PROMPT=1 /usr/bin/python3 -I \
   "$stage_dir/take_screenshot.py" "$@"
 status=$?

--- a/scripts/mini/mini_screenshot_evidence_test.rb
+++ b/scripts/mini/mini_screenshot_evidence_test.rb
@@ -2,11 +2,16 @@
 # frozen_string_literal: true
 
 require_relative '../hooks/test/test_framework'
+require 'fileutils'
+require 'open3'
+require 'tmpdir'
 
 include TestFramework
 
 WRAPPER = File.read(File.expand_path('capture-mini-screenshot.sh', __dir__))
 HELPER = File.read(File.expand_path('mini-screenshot-evidence-helper.sh', __dir__))
+HELPER_FILES = %w[ensure_macos_permissions.sh macos_permissions.swift macos_display_info.swift
+                  macos_window_info.swift take_screenshot.py cws_sticky_window_info.swift].freeze
 
 exit(run_tests('Mini Screenshot Evidence Tests') do
   test_category('Locked evidence') do
@@ -16,7 +21,7 @@ exit(run_tests('Mini Screenshot Evidence Tests') do
       assert_includes(WRAPPER, '--no-login-shell')
       assert_includes(WRAPPER, '/usr/bin/env -i')
       assert_includes(WRAPPER, 'if [ "$capture_status" -ne 0 ] && ! $locked_evidence; then')
-      locked_block = WRAPPER[/if \$locked_evidence; then\n  locked_cmd=.*?^elif \$use_local_runner/m]
+      locked_block = WRAPPER[/if \$locked_evidence; then\n  \$preserve_frontmost.*?^elif \$use_local_runner/m]
       assert(locked_block, 'locked evidence branch must be present')
       assert_includes(locked_block, 'if running_in_ssh_session; then')
       assert_includes(locked_block, 'runner_cmd="$cmd"')
@@ -41,6 +46,52 @@ exit(run_tests('Mini Screenshot Evidence Tests') do
       assert_includes(HELPER, 'tree_sha "$stage_dir"')
       assert(!HELPER.include?('/tmp/codex-screenshot-scripts'),
              'locked evidence must not reuse the shared screenshot helper directory')
+      true
+    end
+
+    test('default locked lane still requires an exact activation target') do
+      env = { 'CWS_SCREENSHOT_EXPECTED_HELPER_SHA256' => '0' * 64 }
+      _stdout, stderr, status = Open3.capture3(env, File.expand_path('capture-mini-screenshot.sh', __dir__),
+                                               '--locked-evidence', 'desktop')
+      assert(!status.success?, 'missing activation target must fail')
+      assert_includes(stderr, 'requires an exact Brave PID and window title')
+      true
+    end
+
+    test('preserve-frontmost lane reaches the locked helper without activation') do
+      Dir.mktmpdir('mini-screenshot-evidence-', '/private/tmp') do |helper_dir|
+        source_dir = File.join(Dir.home, '.codex/skills/screenshot/scripts')
+        HELPER_FILES.each do |file|
+          source = if file == 'cws_sticky_window_info.swift'
+                     File.expand_path('../../../../SaneLotAuctionRelease/extension/scripts/cws_sticky_window_info.swift', __dir__)
+                   else
+                     File.join(source_dir, file)
+                   end
+          FileUtils.cp(source, File.join(helper_dir, file))
+          File.chmod(0o600, File.join(helper_dir, file))
+        end
+        env = { 'CWS_SCREENSHOT_EXPECTED_HELPER_SHA256' => '0' * 64,
+                'LOCAL_SCREENSHOT_HELPER_DIR' => helper_dir }
+        stdout, stderr, status = Open3.capture3(env, File.expand_path('capture-mini-screenshot.sh', __dir__),
+                                                '--skip-cleanup', '--locked-evidence', '--preserve-frontmost', 'desktop')
+        output = stdout + stderr
+        assert(!status.success?, 'deliberately wrong helper hash must fail')
+        assert(output.include?('source hash does not match'), "locked helper was not reached: #{output.inspect}")
+        assert(!output.include?('requires an exact Brave PID'), 'preserve mode must not require activation')
+      end
+      true
+    end
+
+    test('preserve-frontmost is locked-only and mutually exclusive with activation') do
+      wrapper = File.expand_path('capture-mini-screenshot.sh', __dir__)
+      _stdout, stderr, status = Open3.capture3(wrapper, '--preserve-frontmost', 'desktop')
+      assert(!status.success?, 'unlocked preserve mode must fail')
+      assert_includes(stderr, 'requires --locked-evidence')
+      env = { 'CWS_SCREENSHOT_EXPECTED_HELPER_SHA256' => '0' * 64 }
+      _stdout, stderr, status = Open3.capture3(env, wrapper, '--locked-evidence', '--preserve-frontmost',
+                                               '--activate-pid', Process.pid.to_s, '--window-title', 'Brave', 'desktop')
+      assert(!status.success?, 'preserve mode plus activation must fail')
+      assert_includes(stderr, 'cannot also activate a window')
       true
     end
   end


### PR DESCRIPTION
Adds an explicit locked-evidence mode for capturing an already-frontmost transient Brave toolbar popup without re-raising and dismissing it. The default PID/title activation contract remains mandatory. Includes behavioral coverage for both lanes.

Focused evidence: 5/5 Mini screenshot evidence tests, Bash syntax checks, diff check, 500-line wrapper cap, independent P1/P2 review.